### PR TITLE
ci: Add "test:" prefix to allowed PR titles

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check PR Title
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
-          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: " # title should start with the given prefix
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: , test: " # title should start with the given prefix
   labeller:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Pull Request

## Description

This change adds the "test: " prefix to the list of allowed prefixes for pull request titles in the GitHub Actions workflow. This modification allows pull requests related to testing to be properly recognised and processed by the automated checks.

fixes #119