### PR TITLE
build: Run End to End Tests Locally

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,15 +7,17 @@ mod tests 'tests/tests.just'
 # ------------------------------------------------------------------------------
 
 dashboard-docker-build:
-    just dashboard::install dashboard::build
-    cp -r dashboard/out docker/dashboard
     cd docker/dashboard && docker build -t github-stats-dashboard -f Dockerfile .
 
+end-to-end-tests-docker-build:
+    cp tests/poetry.lock tests/pyproject.toml docker/end_to_end_tests
+    cd docker/end_to_end_tests && docker build -t end-to-end-tests -f Dockerfile .
+
 compose-up:
-    docker compose -f=docker/docker-compose.yml up -d
+    docker compose -f=docker/docker-compose-local-test.yml up
 
 compose-down:
-    docker compose -f=docker/docker-compose.yml down
+    docker compose -f=docker/docker-compose-local-test.yml down
 
 # ------------------------------------------------------------------------------
 # Prettier

--- a/dashboard/dashboard.just
+++ b/dashboard/dashboard.just
@@ -12,7 +12,10 @@ dev:
 
 # Build an optimized production version of the app
 build:
-    npm run build
+    npm run build && npm run postbuild
+
+build-local:
+    npm run build:local && npm run postbuild:local
 
 # Lint typescript code with ESLint
 lint:

--- a/dashboard/next-sitemap.config.mjs
+++ b/dashboard/next-sitemap.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next-sitemap').IConfig} */
 export default {
-  siteUrl: process.env.SITE_URL || "https://jackplowman.github.io/github-stats",
+  // siteUrl: process.env.SITE_URL || "https://jackplowman.github.io/github-stats",
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
   generateRobotsTxt: true,
   output: "export",
 };

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,9 +7,11 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "SITE_URL=http://localhost:3000/github-stats next dev",
+    "dev": "NEXT_PUBLIC_SITE_URL=http://localhost:3000/github-stats next dev",
     "build": "next build",
     "postbuild": "next-sitemap --config next-sitemap.config.mjs",
+    "build:local": "NEXT_PUBLIC_SITE_URL=http://localhost:8000 next build",
+    "postbuild:local": "NEXT_PUBLIC_SITE_URL=http://localhost:8000 next-sitemap --config next-sitemap.config.mjs",
     "lint": "next lint",
     "test": "jest",
     "test:coverage": "jest --coverage --silent"

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -4,7 +4,7 @@ FROM nginx:1.27.1
 
 # Copy the nginx configuration file
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-# Copy the static files to the nginx directory
-COPY out /var/www/out
+
+RUN mkdir -p /var/www/out
 
 

--- a/docker/dashboard/nginx.conf
+++ b/docker/dashboard/nginx.conf
@@ -13,6 +13,10 @@ server {
         try_files $uri $uri.html $uri/ =404;
     }
 
+    location /repository/ {
+      rewrite ^/repository/(.*)$ /repository/$1.html break;
+  }
+
     error_page 404 /404.html;
     location = /404.html {
         internal;

--- a/docker/docker-compose-local-test.yml
+++ b/docker/docker-compose-local-test.yml
@@ -1,0 +1,17 @@
+services:
+  dashboard:
+    container_name: dashboard
+    image: github-stats-dashboard
+    ports:
+      - "8000:80"
+    volumes:
+      - ../dashboard/out:/var/www/out
+
+  end_to_end_tests:
+    container_name: end-to-end-tests
+    image: end-to-end-tests
+    command: poetry run pytest end_to_end --gherkin-terminal-reporter
+    environment:
+      - PROJECT_URL=http://host.docker.internal:8000
+    volumes:
+      - ../tests/end_to_end:/end_to_end

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,0 @@
-services:
-  dashboard:
-    container_name: dashboard
-    image: github-stats-dashboard
-    ports:
-      - "8000:80"

--- a/docker/end_to_end_tests/.gitignore
+++ b/docker/end_to_end_tests/.gitignore
@@ -1,0 +1,2 @@
+poetry.lock
+pyproject.toml

--- a/docker/end_to_end_tests/Dockerfile
+++ b/docker/end_to_end_tests/Dockerfile
@@ -1,0 +1,11 @@
+#checkov:skip=CKV_DOCKER_2
+#checkov:skip=CKV_DOCKER_3
+FROM python:3.12-slim
+
+WORKDIR /
+COPY poetry.lock pyproject.toml ./
+
+RUN pip install --no-cache-dir poetry==1.8.3 \
+  && poetry install \
+  && mkdir -p /end_to_end
+

--- a/tests/end_to_end/utils/variables.py
+++ b/tests/end_to_end/utils/variables.py
@@ -1,3 +1,19 @@
 from os import getenv
 
 PROJECT_URL = getenv("PROJECT_URL") if getenv("PROJECT_URL") else "https://jackplowman.github.io/github-stats"
+
+
+def docker_translation(url: str) -> str:
+    """Translates a url from the host machine to the docker container.
+
+    Args:
+        url (str): The url to translate.
+
+    Returns:
+        str: The translated url.
+    """
+    if "host.docker.internal" not in url and "localhost" not in url:
+        return url
+    if "host.docker.internal" in url:
+        return url.replace("host.docker.internal", "localhost")
+    return url.replace("localhost", "host.docker.internal")


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces several changes to improve the project's Docker setup and end-to-end testing capabilities:

1. Updated the `Justfile` to include a new `end-to-end-tests-docker-build` command and modified the `compose-up` and `compose-down` commands to use a new Docker Compose file.

2. Enhanced the dashboard build process by adding a `build-local` command and updating the `package.json` scripts to support local builds.

3. Modified the `next-sitemap.config.mjs` to use the `NEXT_PUBLIC_SITE_URL` environment variable.

4. Updated the Docker setup for the dashboard, including changes to the Dockerfile and nginx configuration.

5. Created a new `docker-compose-local-test.yml` file to support local testing with both the dashboard and end-to-end tests containers.

6. Added a new Dockerfile for end-to-end tests in the `docker/end_to_end_tests` directory.

7. Updated the end-to-end test files to handle Docker-specific URL translations and adjusted content type assertions.

These changes aim to streamline the development and testing process, particularly for local environments, and improve the overall Docker setup for the project.

fixes #122