### PR TITLE
build: Fix and Simplify Local Build Process

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,11 +13,17 @@ end-to-end-tests-docker-build:
     cp tests/poetry.lock tests/pyproject.toml docker/end_to_end_tests
     cd docker/end_to_end_tests && docker build -t end-to-end-tests -f Dockerfile .
 
-compose-up:
+compose-up-local-test:
     docker compose -f=docker/docker-compose-local-test.yml up
 
-compose-down:
+compose-down-local-test:
     docker compose -f=docker/docker-compose-local-test.yml down
+
+compose-up-prod-test:
+    docker compose -f=docker/docker-compose-prod-test.yml up
+
+compose-down-prod-test:
+    docker compose -f=docker/docker-compose-prod-test.yml down
 
 # ------------------------------------------------------------------------------
 # Prettier

--- a/dashboard/dashboard.just
+++ b/dashboard/dashboard.just
@@ -15,7 +15,7 @@ build:
     npm run build && npm run postbuild
 
 build-local:
-    npm run build:local && npm run postbuild:local
+    npm run build && npm run postbuild:local
 
 # Lint typescript code with ESLint
 lint:

--- a/dashboard/next-sitemap.config.mjs
+++ b/dashboard/next-sitemap.config.mjs
@@ -1,7 +1,8 @@
 /** @type {import('next-sitemap').IConfig} */
 export default {
-  // siteUrl: process.env.SITE_URL || "https://jackplowman.github.io/github-stats",
-  siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
+  siteUrl:
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "https://jackplowman.github.io/github-stats",
   generateRobotsTxt: true,
   output: "export",
 };

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,7 +10,6 @@
     "dev": "NEXT_PUBLIC_SITE_URL=http://localhost:3000/github-stats next dev",
     "build": "next build",
     "postbuild": "next-sitemap --config next-sitemap.config.mjs",
-    "build:local": "NEXT_PUBLIC_SITE_URL=http://localhost:8000 next build",
     "postbuild:local": "NEXT_PUBLIC_SITE_URL=http://localhost:8000 next-sitemap --config next-sitemap.config.mjs",
     "lint": "next lint",
     "test": "jest",

--- a/docker/docker-compose-local-test.yml
+++ b/docker/docker-compose-local-test.yml
@@ -13,5 +13,6 @@ services:
     command: poetry run pytest end_to_end --gherkin-terminal-reporter
     environment:
       - PROJECT_URL=http://host.docker.internal:8000
+      - ENVIRONMENT=local
     volumes:
       - ../tests/end_to_end:/end_to_end

--- a/docker/docker-compose-prod-test.yml
+++ b/docker/docker-compose-prod-test.yml
@@ -1,0 +1,10 @@
+services:
+  end_to_end_tests:
+    container_name: end-to-end-tests
+    image: end-to-end-tests
+    command: poetry run pytest end_to_end --gherkin-terminal-reporter
+    environment:
+      - PROJECT_URL=https://jackplowman.github.io/github-stats
+      - ENVIRONMENT=prod
+    volumes:
+      - ../tests/end_to_end:/end_to_end

--- a/tests/end_to_end/steps/test_sitemap.py
+++ b/tests/end_to_end/steps/test_sitemap.py
@@ -2,13 +2,12 @@ from defusedxml.ElementTree import fromstring
 from pytest_bdd import scenarios, then, when
 from requests import Response, get
 
-from end_to_end.utils.variables import PROJECT_URL, docker_translation
+from end_to_end.utils.variables import EXPECTED_XML_CONTENT_TYPE, PROJECT_URL, docker_translation
 
 scenarios("../features/sitemap.feature")
 
 EXPECTED_SITEMAP_PATH = "sitemap-0.xml"
 EXPECTED_SITEMAP_URL = f"{PROJECT_URL}/{EXPECTED_SITEMAP_PATH}"
-EXPECTED_CONTENT_TYPE = "text/xml"
 
 
 @when("I request the sitemap index", target_fixture="sitemap_index_response")
@@ -30,7 +29,7 @@ def step_impl(sitemap_index_response: Response) -> None:
     Args:
         sitemap_index_response (Response): The response from the request.
     """
-    assert sitemap_index_response.headers["Content-Type"] == EXPECTED_CONTENT_TYPE
+    assert sitemap_index_response.headers["Content-Type"] == EXPECTED_XML_CONTENT_TYPE
 
 
 @then("the sitemap index should link to the sitemap")
@@ -40,7 +39,7 @@ def step_impl(sitemap_index_response: Response) -> None:
     Args:
         sitemap_index_response (Response): The response from the request.
     """
-    assert sitemap_index_response.headers["Content-Type"] == EXPECTED_CONTENT_TYPE
+    assert sitemap_index_response.headers["Content-Type"] == EXPECTED_XML_CONTENT_TYPE
     sitemap_index_element = fromstring(sitemap_index_response.content)
     assert sitemap_index_element.tag == "{http://www.sitemaps.org/schemas/sitemap/0.9}sitemapindex"
     sitemap_element = sitemap_index_element.find("{http://www.sitemaps.org/schemas/sitemap/0.9}sitemap")
@@ -67,7 +66,7 @@ def step_impl(sitemap_response: Response) -> None:
     Args:
         sitemap_response (Response): The response from the request.
     """
-    assert sitemap_response.headers["Content-Type"] == EXPECTED_CONTENT_TYPE
+    assert sitemap_response.headers["Content-Type"] == EXPECTED_XML_CONTENT_TYPE
 
 
 @then("the sitemap should contain the project urls")
@@ -77,7 +76,7 @@ def step_impl(sitemap_response: Response) -> None:
     Args:
         sitemap_response (Response): The response from the request.
     """
-    assert sitemap_response.headers["Content-Type"] == EXPECTED_CONTENT_TYPE
+    assert sitemap_response.headers["Content-Type"] == EXPECTED_XML_CONTENT_TYPE
     sitemap_element = fromstring(sitemap_response.content)
     assert sitemap_element.tag == "{http://www.sitemaps.org/schemas/sitemap/0.9}urlset"
     assert len(sitemap_element.findall("{http://www.sitemaps.org/schemas/sitemap/0.9}url")) > 0

--- a/tests/end_to_end/utils/variables.py
+++ b/tests/end_to_end/utils/variables.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 PROJECT_URL = getenv("PROJECT_URL") if getenv("PROJECT_URL") else "https://jackplowman.github.io/github-stats"
+EXPECTED_XML_CONTENT_TYPE = "text/xml" if getenv("ENVIRONMENT") == "local" else "application/xml"
 
 
 def docker_translation(url: str) -> str:


### PR DESCRIPTION
# Pull Request

## Description

This change simplifies the build process and improves URL handling for the dashboard:

1. Modified the `build-local` command in `dashboard.just` to use the standard `npm run build` instead of a separate local build command.

2. Updated `next-sitemap.config.mjs` to use a fallback URL if `NEXT_PUBLIC_SITE_URL` is not set, ensuring the sitemap always has a valid URL.

3. Removed the `build:local` script from `package.json`, as it's no longer needed with the simplified build process.

These changes streamline the build process and make the URL configuration more robust, reducing potential errors and improving maintainability.

fixes #135