### PR TITLE
ci: Remove Analyser Python code quality checks from workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -50,39 +50,6 @@ jobs:
           VALIDATE_TSX: false
           VALIDATE_TSX_PRETTIER: false
 
-  check-python-code-format-and-quality:
-    name: Check Python Code Format and Quality
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Install Python 3.12 with Poetry Cache
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-          cache: "poetry"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: Install Poetry Dependencies
-        run: just analyser::install
-
-      - name: Check Python Code Quality (Ruff)
-        run: just analyser::ruff-lint
-
-      - name: Check Python Code Format (Ruff)
-        run: just analyser::ruff-format
-
-      - name: Check Python Code for Dead Code (Vulture)
-        run: just analyser::vulture
-
   check-typescript-code-format-and-quality:
     name: Check TypeScript Code Format and Quality
     runs-on: ubuntu-latest

--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -e +x
 
-just analyser::install
-just analyser::ruff-fix
 just tests::install
 just tests::ruff-fix


### PR DESCRIPTION
# Pull Request

## Description

This change removes the Python code quality and formatting checks from the GitHub Actions workflow. The `check-python-code-format-and-quality` job has been entirely removed from the `code-quality.yml` file.

Additionally, the pre-commit hook script for Python (`githooks/pre-commit-scripts/python.sh`) has been simplified. It no longer installs the analyser or runs the Ruff fix command for the analyser. The script now only installs and runs Ruff fix for tests.

These changes suggest a shift in the project's approach to Python code quality checks, potentially moving these checks to a different stage of the development process or removing them altogether.

fixes #144