### PR TITLE
chore: Remove Visual Studio Code debug configurations and test settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,25 +5,5 @@
 
   // To get python interpreter path use `poetry debug info`
   "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Debug Analyser",
-      "type": "debugpy",
-      "request": "launch",
-      "module": "application",
-      "cwd": "${workspaceFolder}/analyser",
-      "env": {
-        "DEBUG": "true",
-        "REPOSITORY_OWNER": "JackPlowman"
-      },
-      "console": "integratedTerminal",
-      "justMyCode": true
-    },
-    {
-      "command": "./node_modules/.bin/astro dev",
-      "name": "Dashboard Development server",
-      "request": "launch",
-      "type": "node-terminal"
-    }
-  ]
+  "configurations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-  "python.testing.cwd": "${workspaceFolder}/analyser",
-  "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true,
-  "python.testing.autoTestDiscoverOnSaveEnabled": true,
   "python.analysis.inlayHints.pytestParameters": true,
   "files.exclude": {
     ".ruff_cache": true,


### PR DESCRIPTION
# Pull Request

## Description

This change removes specific debug configurations from the VS Code launch settings. The "Debug Analyser" and "Dashboard Development server" configurations have been removed from `launch.json`. Additionally, in `settings.json`, Python testing-related settings have been removed, including unittest and pytest configurations. These changes simplify the VS Code workspace settings, potentially reducing confusion for developers who may not need these specific configurations.

fixes #159