### PR TITLE
ci: Replace GitHub Stats Analyser with example data file

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -69,16 +69,8 @@ jobs:
           cache: "npm"
           cache-dependency-path: "dashboard/package-lock.json"
 
-      - name: Install Poetry Dependencies
-        run: just analyser::install
-
-      - name: GitHub Stats Analyser
-        uses: JackPlowman/github-stats-analyser@v1.0.1
-        with:
-          repository_owner: ${{ github.repository_owner }}
-
-      - name: Copy generated files to github pages folder
-        run: cp -r repository_statistics.json dashboard/data
+      - name: Copy example file to github pages folder
+        run: cp -r data/repository_statistics.json dashboard/data
 
       - name: Run Build Test
         run: just dashboard-docker-build

--- a/data/repository_statistics.json
+++ b/data/repository_statistics.json
@@ -1,0 +1,19 @@
+[
+  {
+    "repository": "tech-radar",
+    "total_files": 27,
+    "total_commits": 19,
+    "commits": {
+      "Jack Plowman": 19
+    },
+    "languages": {
+      "INI": 1,
+      "Markdown": 2,
+      "CSS+Lasso": 1,
+      "HTML": 1,
+      "JSON": 2,
+      "YAML": 11,
+      "Bash": 3
+    }
+  }
+]


### PR DESCRIPTION
# Pull Request

## Description

This change simplifies the GitHub Actions workflow by removing the GitHub Stats Analyser step and replacing it with a static example file. The workflow now copies a pre-existing `repository_statistics.json` file from the `data` directory to the `dashboard/data` folder, instead of generating statistics dynamically.

A new `repository_statistics.json` file has been added to the `data` directory, containing example statistics for the "tech-radar" repository. This file includes information such as total files, total commits, commit distribution by author, and language breakdown.

These modifications streamline the workflow and provide a consistent dataset for testing and development purposes without relying on external analysis tools.

fixes #152