### PR TITLE
ci: Replace custom analyser with GitHub Stats Analyser action

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -141,13 +141,13 @@ jobs:
       - name: Install Poetry Dependencies
         run: just analyser::install tests::install
 
-      - name: Generate GitHub Pages
-        env:
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-        run: just analyser::run
+      - name: GitHub Stats Analyser
+        uses: JackPlowman/github-stats-analyser@v1.0.1
+        with:
+          repository_owner: ${{ github.repository_owner }}
 
       - name: Copy generated files to github pages folder
-        run: cp -r analyser/statistics/*.json tests/schema_validation
+        run: cp -r repository_statistics.json tests/schema_validation
 
       - name: Validate Schema
         run: just tests::validate-schema
@@ -183,13 +183,13 @@ jobs:
       - name: Install Poetry Dependencies
         run: just analyser::install
 
-      - name: Generate GitHub Pages
-        env:
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-        run: just analyser::run
+      - name: GitHub Stats Analyser
+        uses: JackPlowman/github-stats-analyser@v1.0.1
+        with:
+          repository_owner: ${{ github.repository_owner }}
 
       - name: Copy generated files to github pages folder
-        run: cp -r analyser/statistics/*.json dashboard/data
+        run: cp -r repository_statistics.json dashboard/data
 
       - name: Run Build Test
         run: just dashboard-docker-build

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -113,13 +113,13 @@ jobs:
       - name: Install Poetry Dependencies
         run: just analyser::install
 
-      - name: Generate GitHub Pages
-        env:
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-        run: just analyser::run
+      - name: GitHub Stats Analyser
+        uses: JackPlowman/github-stats-analyser@v1.0.1
+        with:
+          repository_owner: ${{ github.repository_owner }}
 
       - name: Copy generated files to github pages folder
-        run: cp -r analyser/statistics/*.json dashboard/data
+        run: cp -r repository_statistics.json dashboard/data
 
       - name: Build Site
         run: just dashboard::install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,12 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: GitHub Stats Analyser
-        uses: JackPlowman/github-stats-analyser@main
+        uses: JackPlowman/github-stats-analyser@v1.0.1
         with:
           repository_owner: ${{ github.repository_owner }}
 
       - name: Copy generated files to github pages folder
-        run: cp -r analyser/statistics/*.json dashboard/data
+        run: cp -r repository_statistics.json dashboard/data
 
       - name: Install Dashboard Dependencies
         run: just dashboard::install


### PR DESCRIPTION
# Pull Request

## Description

This change updates the GitHub Actions workflows to use the `JackPlowman/github-stats-analyser` action instead of running the analyser locally. The main modifications include:

1. Replacing the `Generate GitHub Pages` step with the `GitHub Stats Analyser` action in the `code-test.yml`, `deploy-preview.yml`, and `deploy.yml` workflows.

2. Updating the copy command to use the new `repository_statistics.json` file instead of the previous `analyser/statistics/*.json` files.

3. Specifying version `v1.0.1` for the `JackPlowman/github-stats-analyser` action in all workflows.

These changes streamline the analysis process and ensure consistency across different workflows. The new approach should improve efficiency and maintainability of the GitHub statistics generation.

fixes #157