### PR TITLE
ci: Refactor test dependencies setup into reusable action

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -1,0 +1,22 @@
+name: "Setup Dependencies"
+description: "Installs dependencies for the project"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry
+
+    - name: Install Python 3.12 with Poetry Cache
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: "tests/pyproject.toml"
+        cache: "poetry"
+
+    - name: Set up Just
+      uses: extractions/setup-just@v2
+
+    - name: Install Poetry Dependencies
+      shell: bash
+      run: just tests::install

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -87,20 +87,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Install Python 3.12 with Poetry Cache
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: "tests/pyproject.toml"
-          cache: "poetry"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: Install Poetry Dependencies
-        run: just tests::install
+      - name: Setup Test Dependencies
+        uses: ./.github/actions/setup-test-dependencies
 
       - name: Check Python Code Quality (Ruff)
         run: just tests::ruff-lint

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -65,20 +65,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Install Python 3.12 with Poetry Cache
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: "tests/pyproject.toml"
-          cache: "poetry"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: Install Poetry Dependencies
-        run: just tests::install
+      - name: Setup Test Dependencies
+        uses: ./.github/actions/setup-test-dependencies
 
       - name: Run tests
         run: just tests::run
@@ -97,9 +85,6 @@ jobs:
 
       - name: Checkout main
         run: git checkout main
-
-      - name: Install Poetry
-        run: pipx install poetry
 
       - name: GitHub Stats Analyser
         uses: JackPlowman/github-stats-analyser@v1.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,20 +73,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Install Python 3.12 with Poetry Cache
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: "tests/pyproject.toml"
-          cache: "poetry"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: Install Poetry Dependencies
-        run: just tests::install
+      - name: Setup Test Dependencies
+        uses: ./.github/actions/setup-test-dependencies
 
       - name: Run tests
         run: just tests::run


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Action named "Setup Dependencies" to streamline the process of installing project dependencies across multiple workflows. The action is defined in `.github/actions/setup-test-dependencies/action.yml` and performs the following tasks:

1. Installs Poetry using pipx
2. Sets up Python 3.12 with Poetry cache
3. Installs the Just command runner
4. Installs Poetry dependencies using the `just tests::install` command

The new action is then utilized in the following workflows:

- `code-quality.yml`
- `deploy-preview.yml`
- `deploy.yml`

In each of these workflows, the previously separate steps for installing dependencies have been replaced with a single step that uses the new `setup-test-dependencies` action. This change reduces code duplication and simplifies the maintenance of dependency installation across different workflows.

Additionally, the `deploy-preview.yml` workflow has been updated to remove a redundant Poetry installation step before running the GitHub Stats Analyser.

These changes improve the consistency and efficiency of the CI/CD pipeline by centralizing the dependency setup process.

fixes #171