### PR TITLE
ci: Refactor dashboard setup and deployment into reusable action

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -1,0 +1,41 @@
+name: "Setup Dependencies"
+description: "Installs dependencies for the project"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js with Cache
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ".node-version"
+        cache: "npm"
+        cache-dependency-path: "dashboard/package-lock.json"
+
+    - name: Set up Just
+      uses: extractions/setup-just@v2
+
+    - name: GitHub Stats Analyser
+      uses: JackPlowman/github-stats-analyser@v1.0.1
+      with:
+        repository_owner: ${{ github.repository_owner }}
+
+    - name: Copy generated files to github pages folder
+      shell: bash
+      run: cp -r repository_statistics.json dashboard/data
+
+    - name: Install Dashboard Dependencies
+      shell: bash
+      run: just dashboard::install
+
+    - name: Build Site
+      shell: bash
+      run: just dashboard::build
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: dashboard/out
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -21,38 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node.js with Cache
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "npm"
-          cache-dependency-path: "dashboard/package-lock.json"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: GitHub Stats Analyser
-        uses: JackPlowman/github-stats-analyser@v1.0.1
-        with:
-          repository_owner: ${{ github.repository_owner }}
-
-      - name: Copy generated files to github pages folder
-        run: cp -r repository_statistics.json dashboard/data
-
-      - name: Install Dashboard Dependenciesg
-        run: just dashboard::install
-
-      - name: Build Site
-        run: just dashboard::build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dashboard/out
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Setup and Deploy Dashboard
+        uses: ./.github/actions/setup-and-deploy-dashboard
 
   test-deployment:
     name: Test GitHub Pages Deployment
@@ -86,25 +56,5 @@ jobs:
       - name: Checkout main
         run: git checkout main
 
-      - name: GitHub Stats Analyser
-        uses: JackPlowman/github-stats-analyser@v1.0.1
-        with:
-          repository_owner: ${{ github.repository_owner }}
-
-      - name: Copy generated files to github pages folder
-        run: cp -r repository_statistics.json dashboard/data
-
-      - name: Build Site
-        run: just dashboard::install
-
-      - name: Build Site
-        run: just dashboard::build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dashboard/out
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Setup and Deploy Dashboard
+        uses: ./.github/actions/setup-and-deploy-dashboard

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,34 +22,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node.js with Cache
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "npm"
-          cache-dependency-path: "dashboard/package-lock.json"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: GitHub Stats Analyser
-        uses: JackPlowman/github-stats-analyser@v1.0.1
-        with:
-          repository_owner: ${{ github.repository_owner }}
-
-      - name: Copy generated files to github pages folder
-        run: cp -r repository_statistics.json dashboard/data
-
-      - name: Install Dashboard Dependencies
-        run: just dashboard::install
-
-      - name: Build Site
-        run: just dashboard::build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dashboard/out
+      - name: Setup and Deploy Dashboard
+        uses: ./.github/actions/setup-and-deploy-dashboard
 
   deploy:
     needs: build


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Action named "Setup Dependencies" in `.github/actions/setup-and-deploy-dashboard/action.yml`. This action encapsulates the process of setting up Node.js, installing Just, running the GitHub Stats Analyser, copying generated files, installing dashboard dependencies, building the site, and deploying to GitHub Pages.

The workflows in `deploy-preview.yml` and `deploy.yml` have been refactored to use this new action, replacing the individual steps previously defined in these files. This simplifies the workflow definitions and promotes code reuse.

In the `deploy-preview.yml` workflow, both the `deploy-preview` and `test-deployment` jobs now use the new action. Similarly, in the `deploy.yml` workflow, the `build` job has been updated to use the new action.

These changes streamline the deployment process, reduce duplication, and make it easier to maintain and update the deployment steps across different workflows.

fixes #172