### PR TITLE
ci: Add dependency groups for GitHub Actions and Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "tests"
@@ -40,3 +44,7 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "main"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Pull Request

## Description

This change updates the Dependabot configuration to introduce grouping for GitHub Actions and Docker dependencies. 

For GitHub Actions, all dependencies are now grouped under "github-actions". This means that Dependabot will create a single pull request for all GitHub Actions updates, rather than individual PRs for each action.

Similarly, for Docker dependencies, all updates are grouped under "docker". This will result in consolidated pull requests for Docker-related updates.

These changes aim to reduce the number of individual pull requests created by Dependabot, making dependency management more streamlined and easier to handle.

fixes #178