### PR TITLE
chore: Fix dependabot not checking composite actions for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,10 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - ".github/actions/setup-and-deploy-dashboard"
+      - ".github/actions/setup-test-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:


### PR DESCRIPTION
# Pull Request

## Description

This change expands the scope of Dependabot's GitHub Actions updates. In addition to the root directory, Dependabot will now also monitor and update dependencies in two specific action directories:

- `.github/actions/setup-and-deploy-dashboard`
- `.github/actions/setup-test-dependencies`

This enhancement ensures that all GitHub Actions used in the project, including those in custom action directories, are kept up-to-date automatically.

fixes #180