### PR TITLE
ci: Use Docker image for GitHub Stats Analyser action

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -1,6 +1,11 @@
 name: "Setup Dependencies"
 description: "Installs dependencies for the project"
 
+inputs:
+  token:
+    description: "A Github PAT"
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -15,9 +20,10 @@ runs:
       uses: extractions/setup-just@v2
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@v1.1.0
+      uses: docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0
       with:
-        repository_owner: ${{ github.repository_owner }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        REPOSITORY_OWNER: ${{ github.repository_owner }}
 
     - name: Copy generated files to github pages folder
       shell: bash

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Setup and Deploy Dashboard
         uses: ./.github/actions/setup-and-deploy-dashboard
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-deployment:
     name: Test GitHub Pages Deployment
@@ -65,3 +67,5 @@ jobs:
 
       - name: Setup and Deploy Dashboard
         uses: ./.github/actions/setup-and-deploy-dashboard
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup and Deploy Dashboard
         uses: ./.github/actions/setup-and-deploy-dashboard
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     needs: build


### PR DESCRIPTION
# Pull Request

## Description

This change updates the GitHub Stats Analyser action in the setup-and-deploy-dashboard workflow. The action now uses a Docker container from the GitHub Container Registry (ghcr.io) instead of directly referencing the action by its GitHub repository.

The updated line now reads:
```yaml
uses: docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0
```

This modification ensures that the action runs from a containerised environment, potentially improving consistency and isolation during execution.

fixes #185