### PR TITLE
chore: Optimise pre-commit hooks for selective execution

### DIFF
--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e +x
 
-just tests::install
-just tests::ruff-fix
+# Check if there are any changes in the watched folder
+if git diff --cached --name-only | grep -q "^tests/"; then
+  just tests::install
+  just tests::ruff-fix
+fi

--- a/githooks/pre-commit-scripts/typescript.sh
+++ b/githooks/pre-commit-scripts/typescript.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e +x
 
-just dashboard::install
-
-just dashboard::lint
+# Check if there are any changes in the watched folder
+if git diff --cached --name-only | grep -q "^dashboard/"; then
+  just dashboard::install
+  just dashboard::lint
+fi


### PR DESCRIPTION
# Pull Request

## Description

This change optimises the pre-commit hooks for Python and TypeScript files. The scripts now only run their respective installation and linting commands when changes are detected in the relevant directories.

For Python files, the script checks for changes in the `tests/` directory before running `just tests::install` and `just tests::ruff-fix`.

For TypeScript files, the script checks for changes in the `dashboard/` directory before running `just dashboard::install` and `just dashboard::lint`.

These modifications improve the efficiency of the pre-commit process by avoiding unnecessary operations when no relevant files have been changed.

fixes #92