### PR TITLE
ci: Update GitHub Stats Analyser action usage

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: extractions/setup-just@v2
 
     - name: GitHub Stats Analyser
-      uses: docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0
+      uses: JackPlowman/github-stats-analyser@v1.1.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
# Pull Request

## Description

This change updates the GitHub Stats Analyser action in the setup-and-deploy-dashboard workflow. The action is now referenced using `JackPlowman/github-stats-analyser@v1.1.0` instead of `docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0`. This modification removes the explicit Docker reference, potentially simplifying the action usage and improving compatibility.

fixes #198