### PR TITLE
ci: Bump GitHub Stats Analyser action to v1.2.0

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: extractions/setup-just@v2
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@v1.1.0
+      uses: JackPlowman/github-stats-analyser@v1.2.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
# Pull Request

## Description

This change updates the GitHub Stats Analyser action in the setup-and-deploy-dashboard workflow. The version of the JackPlowman/github-stats-analyser action has been upgraded from v1.1.0 to v1.2.0. This update ensures that the workflow is using the latest version of the GitHub Stats Analyser, which may include bug fixes, performance improvements, or new features.

fixes #197