### PR TITLE
chore: Add size labels to GitHub configuration

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -76,3 +76,22 @@
 - color: f200f2
   name: analyser
   description: Pull requests that update analyser code
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request


### PR DESCRIPTION
# Pull Request

## Description

This change adds new labels to categorise pull requests based on their size. The following size labels have been introduced:

- size/XS: Extra Small Pull Request
- size/S: Small Pull Request
- size/M: Medium Pull Request
- size/L: Large Pull Request
- size/XL: Extra Large Pull Request
- size/XXL: Extra Extra Large Pull Request

Each label is assigned a unique colour for easy visual identification. This addition will help in quickly assessing the scope and complexity of pull requests, facilitating more efficient code review processes and project management.

fixes #204