### PR TITLE
ci: Add Schedule for Regular Deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change adds a scheduled trigger to the workflow to run at midnight every day.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R8-R9): Added a `schedule` trigger with a cron expression to run the workflow daily at midnight.

Fixes #224 
