### PR TITLE
ci: Set Ruff Output

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -93,9 +93,13 @@ jobs:
 
       - name: Check Python Code Quality (Ruff)
         run: just tests::ruff-lint
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
 
       - name: Check Python Code Format (Ruff)
         run: just tests::ruff-format
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
 
   check-markdown-links:
     name: Check Markdown links


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change sets the `RUFF_OUTPUT_FORMAT` environment variable to "github" for both the "Check Python Code Quality (Ruff)" and "Check Python Code Format (Ruff)" jobs to ensure the output is formatted correctly for GitHub.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R96-R102): Added `RUFF_OUTPUT_FORMAT` environment variable set to "github" for Ruff lint and format checks.

Fixes #253 
