### PR TITLE
ci: Upload Ruff SARIF Results

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -110,8 +110,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Python Dependencies
-        uses: ./.github/actions/setup-dependencies
+      - name: Setup Test Dependencies
+        uses: ./.github/actions/setup-test-dependencies
 
       - name: Check Python Code Quality (Ruff)
         run: just ruff-lint

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -101,6 +101,56 @@ jobs:
         env:
           RUFF_OUTPUT_FORMAT: "github"
 
+        upload-ruff-analysis-results:
+          name: Upload Ruff Analysis Results
+          runs-on: ubuntu-latest
+          steps:
+            - name: Checkout
+              uses: actions/checkout@v4.2.2
+              with:
+                fetch-depth: 0
+
+            - name: Setup Python Dependencies
+              uses: ./.github/actions/setup-dependencies
+
+            - name: Check Python Code Quality (Ruff)
+              run: just ruff-lint
+              env:
+                RUFF_OUTPUT_FORMAT: "sarif"
+                RUFF_OUTPUT_FILE: "ruff-results.sarif"
+              continue-on-error: true
+
+            - name: Upload Ruff analysis results to GitHub
+              uses: github/codeql-action/upload-sarif@v3.27.0
+              with:
+                sarif_file: ruff-results.sarif
+                wait-for-processing: true
+
+  upload-ruff-analysis-results:
+    name: Upload Ruff Analysis Results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-dependencies
+
+      - name: Check Python Code Quality (Ruff)
+        run: just ruff-lint
+        env:
+          RUFF_OUTPUT_FORMAT: "sarif"
+          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+        continue-on-error: true
+
+      - name: Upload Ruff analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3.27.4
+        with:
+          sarif_file: ruff-results.sarif
+          wait-for-processing: true
+
   check-markdown-links:
     name: Check Markdown links
     runs-on: ubuntu-latest

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -101,31 +101,6 @@ jobs:
         env:
           RUFF_OUTPUT_FORMAT: "github"
 
-        upload-ruff-analysis-results:
-          name: Upload Ruff Analysis Results
-          runs-on: ubuntu-latest
-          steps:
-            - name: Checkout
-              uses: actions/checkout@v4.2.2
-              with:
-                fetch-depth: 0
-
-            - name: Setup Python Dependencies
-              uses: ./.github/actions/setup-dependencies
-
-            - name: Check Python Code Quality (Ruff)
-              run: just ruff-lint
-              env:
-                RUFF_OUTPUT_FORMAT: "sarif"
-                RUFF_OUTPUT_FILE: "ruff-results.sarif"
-              continue-on-error: true
-
-            - name: Upload Ruff analysis results to GitHub
-              uses: github/codeql-action/upload-sarif@v3.27.0
-              with:
-                sarif_file: ruff-results.sarif
-                wait-for-processing: true
-
   upload-ruff-analysis-results:
     name: Upload Ruff Analysis Results
     runs-on: ubuntu-latest

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -117,7 +117,7 @@ jobs:
         run: just tests::ruff-lint
         env:
           RUFF_OUTPUT_FORMAT: "sarif"
-          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+          RUFF_OUTPUT_FILE: "tests/ruff-results.sarif"
         continue-on-error: true
 
       - name: Upload Ruff analysis results to GitHub

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -114,7 +114,7 @@ jobs:
         uses: ./.github/actions/setup-test-dependencies
 
       - name: Check Python Code Quality (Ruff)
-        run: just ruff-lint
+        run: just tests::ruff-lint
         env:
           RUFF_OUTPUT_FORMAT: "sarif"
           RUFF_OUTPUT_FILE: "ruff-results.sarif"


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow for uploading Ruff analysis results. This change aims to enhance the code quality checks by incorporating Ruff, a tool for linting Python code.

Enhancements to code quality checks:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R104-R153): Added a new job `upload-ruff-analysis-results` to run Ruff linting on Python code, upload the results in SARIF format, and ensure they are processed by GitHub.

Fixes #247 
