### PR TITLE
chore: Add Linkinator Timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,3 +76,4 @@ jobs:
         with:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
+          timeout: 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,4 +76,4 @@ jobs:
         with:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
-          timeout: 5
+          timeout: 5000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,3 +77,4 @@ jobs:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
           timeout: 1000
+          markdown: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,3 +77,4 @@ jobs:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
           timeout: 5000
+          verbosity: DEBUG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,4 +76,4 @@ jobs:
         with:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
-          timeout: 5000
+          timeout: 1000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,4 +77,3 @@ jobs:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
           timeout: 5000
-          linksToSkip: "https://github.com/"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,3 +78,5 @@ jobs:
           recurse: true
           timeout: 5000
           verbosity: DEBUG
+        env:
+          ACTIONS_STEP_DEBUG: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,4 @@ jobs:
           paths: https://jackplowman.github.io/github-stats
           recurse: true
           timeout: 5000
-          verbosity: DEBUG
-        env:
-          ACTIONS_STEP_DEBUG: true
+          linksToSkip: "https://github.com/"

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,0 +1,3 @@
+{
+  "verbosity": "debug"
+}

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,3 +1,0 @@
-{
-  "verbosity": "debug"
-}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change adds a timeout and disables markdown formatting for the deployment process.

Changes in deployment configuration:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R79-R80): Added `timeout` parameter set to 1000 and `markdown` parameter set to false in the `jobs` section.

Fixes #269 
