### PR TITLE
chore: Fix Website Title

### DIFF
--- a/dashboard/app/(pages)/layout.tsx
+++ b/dashboard/app/(pages)/layout.tsx
@@ -6,7 +6,7 @@ import Navbar from "@/components/NavBar";
 import "../globals.css";
 
 export const metadata: Metadata = {
-  title: "GitHub Stats Dashboard2",
+  title: "GitHub Stats Dashboard",
   description: "Dashboard to Display GitHub Statistics",
 };
 

--- a/dashboard/app/(pages)/layout.tsx
+++ b/dashboard/app/(pages)/layout.tsx
@@ -6,7 +6,7 @@ import Navbar from "@/components/NavBar";
 import "../globals.css";
 
 export const metadata: Metadata = {
-  title: "GitHub Stats DashboardW",
+  title: "GitHub Stats Dashboard",
   description: "Dashboard to Display GitHub Statistics",
 };
 

--- a/dashboard/app/(pages)/layout.tsx
+++ b/dashboard/app/(pages)/layout.tsx
@@ -6,7 +6,7 @@ import Navbar from "@/components/NavBar";
 import "../globals.css";
 
 export const metadata: Metadata = {
-  title: "GitHub Stats Dashboard",
+  title: "GitHub Stats DashboardW",
   description: "Dashboard to Display GitHub Statistics",
 };
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `dashboard/app/(pages)/layout.tsx` file. The change updates the `title` in the `metadata` object to correct the title of the GitHub stats dashboard. 

* [`dashboard/app/(pages)/layout.tsx`](diffhunk://#diff-eccb9739626633732856b964129e6b2fe77b678efa9c22e404b1576476566583L9-R9): Changed the `title` from "GitHub Stats Dashboard2" to "GitHub Stats DashboardW".

Fixes #278 
