### PR TITLE
chore: Fix CodeQL Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -179,6 +179,8 @@ jobs:
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     strategy:
       matrix:
         language: [python, javascript]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change adds permissions to write security events for the CodeQL Analysis job.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R182-R183): Added `permissions` to allow writing security events for the `run-codeql-analysis` job.

Fixes #286 
