### PR TITLE
refactor: Improve GitHub workflow permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -8,13 +8,13 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  statuses: write
 
 jobs:
   check-code-quality:
     name: Check Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -53,6 +53,8 @@ jobs:
   check-typescript-code-format-and-quality:
     name: Check TypeScript Code Format and Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -97,6 +99,8 @@ jobs:
   check-tests-code-format-and-quality:
     name: Check Tests Code Format and Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -120,6 +124,7 @@ jobs:
     name: Upload Ruff Analysis Results
     runs-on: ubuntu-latest
     permissions:
+      statuses: write
       security-events: write
     steps:
       - name: Checkout
@@ -146,6 +151,8 @@ jobs:
   check-markdown-links:
     name: Check Markdown links
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -164,6 +171,8 @@ jobs:
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -180,6 +189,7 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     permissions:
+      statuses: write
       security-events: write
     strategy:
       matrix:
@@ -198,6 +208,8 @@ jobs:
   typescript-unit-tests:
     name: Test TypeScript Code
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -229,6 +241,8 @@ jobs:
   docker-build-test:
     name: Docker Build Test
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -248,9 +262,9 @@ jobs:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
     permissions:
+      statuses: write
       security-events: write
       id-token: write
-
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,8 @@ on:
     - cron: "0 0 * * *"
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
+
 
 jobs:
   build:
@@ -33,6 +32,9 @@ jobs:
     needs: build
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -14,7 +14,7 @@ jobs:
   configure-labels:
     runs-on: ubuntu-latest
     permissions:
-        pull-requests: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,11 +9,12 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   configure-labels:
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the permissions for various jobs in GitHub Actions workflows. The main changes involve ensuring that the `statuses: write` permission is explicitly set for multiple jobs across different workflows.

### Updates to GitHub Actions workflows:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L11-R17): Added `statuses: write` permission to several jobs including `check-code-quality`, `check-typescript-code-format-and-quality`, `check-tests-code-format-and-quality`, `Upload Ruff Analysis Results`, `check-markdown-links`, `check-justfile-format`, `CodeQL Analysis`, `typescript-unit-tests`, `docker-build-test`, and `Scorecard Analysis`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L11-R17) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R56-R57) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R102-R103) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R127) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R154-R155) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R174-R175) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R192) [[8]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R211-R212) [[9]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R244-R245) [[10]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R265-L253)

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R12): Modified permissions to set `contents: read` globally and added `pages: write` and `id-token: write` permissions to the `Deploy to GitHub Pages` job. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R12) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R34-R36)

* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L12-R17): Added `pull-requests: write` permission to the `configure-labels` job.

Fixes #288
