### PR TITLE
chore: Fix Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -33,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -33,8 +34,6 @@ jobs:
     needs: build
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write
       pages: write
     steps:
@@ -34,6 +33,9 @@ jobs:
     needs: build
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -46,7 +48,6 @@ jobs:
     name: UI Tests
     runs-on: ubuntu-latest
     needs: deploy
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -65,7 +66,6 @@ jobs:
     name: Link Tests
     runs-on: ubuntu-latest
     needs: deploy
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/deploy.yml` file. The most important changes involve adding permissions for the `id-token` and `pages`, and removing unnecessary blank lines in the job steps.

Permissions updates:

* Added `id-token: write` and `pages: write` permissions to the `build` job.
* Ensured `pages: write` permission is correctly ordered after `id-token: write` in the `Deploy to GitHub Pages` job.

Code cleanup:

* Removed unnecessary blank lines in the `UI Tests` job steps.
* Removed unnecessary blank lines in the `Link Tests` job steps.

Fixes #292 
