### PR TITLE
ci: Add Code Limit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -294,7 +294,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 'Run Code Limit'
+      - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -278,14 +278,24 @@ jobs:
           results_format: sarif
           publish_results: true
 
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@v3.27.4
         with:
           sarif_file: results.sarif
+
+  run-code-limit:
+    name: Code Limit Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: 'Run Code Limit'
+        uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          upload: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflow configuration to enhance code analysis and artifact management. The most important changes include the removal of an artifact upload step and the addition of a new job for code limit analysis.

Enhancements to code analysis and artifact management:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L281-R301): Removed the "Upload artifact" step that used `actions/upload-artifact@v4.4.3` to upload the SARIF file.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L281-R301): Added a new job named "Code Limit Analysis" that runs on `ubuntu-latest`, checks out the repository, and uses `getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0` to run code limit analysis and upload results.

Fixes #298 
