### PR TITLE
chore: Update Repository Labels

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -2,7 +2,17 @@
 documentation:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["README.md", "docs/**"]
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
 dependencies:
   - any:
       - changed-files:
@@ -28,8 +38,7 @@ shell:
 github_actions:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [".github/workflows/*", ".github/workflows/**/*"]
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
 end-to-end-tests:
   - any:
       - changed-files:
@@ -42,7 +51,7 @@ dashboard:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["dashboard/**"]
-git-hooks:
+git_hooks:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["githooks/**"]

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -61,6 +61,9 @@
 - color: 00ff44
   name: shell
   description: Pull requests that update Shell code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
 # Custom
 - color: 00f2de
   name: end-to-end-tests


### PR DESCRIPTION
## Description

This pull request includes updates to the `.github/other-configurations/labeller.yml` and `.github/other-configurations/labels.yml` files to improve the categorization and labeling of pull requests. The most important changes include the addition of a new label for markdown files, updates to the glob patterns for file matching, and corrections to existing labels.

Updates to file categorization:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L5-R15): Added a new `markdown` category to label changes to markdown files, including `README.md`, `LICENSE`, and other markdown files in the repository.
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L31-R41): Updated the `github_actions` category to include changes to files in the `.github/actions` directory.
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L45-R54): Corrected the label name from `git-hooks` to `git_hooks` for consistency.

Updates to labels:

* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR64-R66): Added a new label for `markdown` with a description and color code.

Fixes #311 