### PR TITLE
build: Add Dashboard Web Manifest

### DIFF
--- a/dashboard/app/manifest.ts
+++ b/dashboard/app/manifest.ts
@@ -1,20 +1,20 @@
-import type { MetadataRoute } from 'next'
+import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: 'GitHub Stats Dashboard',
-    short_name: 'GH Stats Dashboard',
-    description: 'A dashboard to view Jack\'s GitHub stats',
-    start_url: '/github-stats',
-    display: 'standalone',
-    background_color: '#fff',
-    theme_color: '#fff',
+    name: "GitHub Stats Dashboard",
+    short_name: "GH Stats Dashboard",
+    description: "A dashboard to view Jack's GitHub stats",
+    start_url: "/github-stats",
+    display: "standalone",
+    background_color: "#fff",
+    theme_color: "#fff",
     icons: [
       {
-        src: '/favicon.ico',
-        sizes: 'any',
-        type: 'image/x-icon',
+        src: "/favicon.ico",
+        sizes: "any",
+        type: "image/x-icon",
       },
     ],
-  }
+  };
 }

--- a/dashboard/app/manifest.ts
+++ b/dashboard/app/manifest.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'GitHub Stats Dashboard',
+    short_name: 'GH Stats Dashboard',
+    description: 'A dashboard to view Jack\'s GitHub stats',
+    start_url: '/github-stats',
+    display: 'standalone',
+    background_color: '#fff',
+    theme_color: '#fff',
+    icons: [
+      {
+        src: '/favicon.ico',
+        sizes: 'any',
+        type: 'image/x-icon',
+      },
+    ],
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new manifest file for the GitHub Stats Dashboard. The change includes the creation of a manifest that defines various properties for the web application, such as its name, description, start URL, display mode, background color, theme color, and icons.

Key changes:

* [`dashboard/app/manifest.ts`](diffhunk://#diff-71894ed18b15580e1ec8d7f0bca98bd224ad48390038d456236c02b4673d7345R1-R20): Added a new manifest file that includes metadata for the GitHub Stats Dashboard, defining its name, short name, description, start URL, display mode, background color, theme color, and icons.

Fixes #313 
