### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,10 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,7 +25,10 @@ updates:
     commit-message:
       prefix: "deps(python-tests)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
@@ -34,7 +40,10 @@ updates:
     commit-message:
       prefix: "deps(typescript)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       typescript:
@@ -46,7 +55,10 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       docker:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/dependabot.yml` file to update the dependency update schedules for various groups. The most important changes include modifying the update intervals, adding specific days and times for updates, and setting the timezone.

Changes to update schedules:

* Changed the update interval for `github-actions` from daily to weekly, and specified updates to occur on Saturday at 01:00 in the Europe/London timezone. (`.github/dependabot.yml`)
* Changed the update interval for `python-tests` from monthly to weekly, and specified updates to occur on Saturday at 01:00 in the Europe/London timezone. (`.github/dependabot.yml`)
* Changed the update interval for `typescript` from monthly to weekly, and specified updates to occur on Saturday at 01:00 in the Europe/London timezone. (`.github/dependabot.yml`)
* Changed the update interval for `docker` from monthly to weekly, and specified updates to occur on Saturday at 01:00 in the Europe/London timezone. (`.github/dependabot.yml`)

Fixes #323 