### PR TITLE
ci: Prevent multiple deployments from running concurrently

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/deploy.yml`. The change introduces a concurrency group to ensure that only one instance of the workflow runs at a time.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R14-R16): Added a `concurrency` group to the workflow configuration to prevent multiple instances from running concurrently.

Fixes #330
