### PR TITLE
deps(typescript): Update Many Typescript Dependencies

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,23 +9,25 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-avatar": "1.1.0",
-        "@radix-ui/react-dropdown-menu": "2.1.1",
-        "@radix-ui/react-icons": "1.3.0",
-        "@radix-ui/react-navigation-menu": "1.2.0",
-        "class-variance-authority": "0.7.0",
+        "@radix-ui/react-avatar": "1.1.1",
+        "@radix-ui/react-dropdown-menu": "2.1.2",
+        "@radix-ui/react-icons": "1.3.2",
+        "@radix-ui/react-navigation-menu": "1.2.1",
+        "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
-        "lucide-react": "0.441.0",
-        "marked": "15.0.0",
+        "lucide-react": "0.461.0",
+        "marked": "15.0.2",
         "next": "14.2.11",
         "next-sitemap": "4.2.3",
         "octokit": "4.0.2",
         "react": "18",
         "react-dom": "18",
-        "recharts": "2.12.7",
-        "tailwind-merge": "2.5.2",
+        "recharts": "2.13.3",
+        "tailwind-merge": "2.5.5",
+        "tailwindcss": "3.4.15",
         "tailwindcss-animate": "1.0.7",
-        "ts-node": "10.9.2"
+        "ts-node": "10.9.2",
+        "typescript": "5.4.5"
       },
       "devDependencies": {
         "@microsoft/eslint-formatter-sarif": "3.1.0",
@@ -43,9 +45,7 @@
         "jest-environment-jsdom": "29.7.0",
         "postcss": "8",
         "prettier": "3.3.3",
-        "resize-observer-polyfill": "1.5.1",
-        "tailwindcss": "3.4.1",
-        "typescript": "5.4.5"
+        "resize-observer-polyfill": "1.5.1"
       },
       "engines": {
         "node": ">=22.8.0",
@@ -1610,28 +1610,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
-      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
-      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
-      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
-      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2846,12 +2846,12 @@
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.0.tgz",
-      "integrity": "sha512-Q/PbuSMk/vyAd/UoIShVGZ7StHHeRFYU7wXmi5GV+8cLXflZAEpHL/F697H1klrzxKXNtZ97vWiC0q3RKUH8UA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.1.tgz",
+      "integrity": "sha512-eoOtThOmxeoizxpX6RiEsQZ2wj5r4+zoeqAwO0cBaFQGjJwIH3dIX0OCxNrCyrrdxG+vBweMETh3VziQG7c1kw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.0"
@@ -2867,6 +2867,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2943,9 +2958,9 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
-      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
@@ -2970,16 +2985,16 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.1.tgz",
-      "integrity": "sha512-y8E+x9fBq9qvteD2Zwa4397pUVhYsh9iq44b5RD5qu1GMJWBCBuVg1hMyItbc6+zH00TxGRqd9Iot4wzf3OoBQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.2.tgz",
+      "integrity": "sha512-GVZMR+eqK8/Kes0a36Qrv+i20bAPXSn8rCBTHx30w+3ECnR5o3xixAlqcVaYvLeyKUsm0aqyhWfmUcqufM8nYA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-menu": "2.1.1",
+        "@radix-ui/react-menu": "2.1.2",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
       },
@@ -2998,10 +3013,25 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
-      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3039,12 +3069,12 @@
       }
     },
     "node_modules/@radix-ui/react-icons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
-      "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.x || ^17.x || ^18.x"
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@radix-ui/react-id": {
@@ -3066,29 +3096,29 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.1.tgz",
-      "integrity": "sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.2.tgz",
+      "integrity": "sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-collection": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.0",
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-popper": "1.2.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-roving-focus": "1.1.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3105,20 +3135,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-navigation-menu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.0.tgz",
-      "integrity": "sha512-OQ8tcwAOR0DhPlSY3e4VMXeHiol7la4PPdJWhhwJiJA+NLX0SaCaonOkRnI3gCDHoZ7Fo7bb/G6q25fRM2Y+3Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.1.tgz",
+      "integrity": "sha512-egDo0yJD2IK8L17gC82vptkvW1jLeni1VuqCyzY727dSJdk5cDjINomouLoNk8RVF7g2aNIfENKWL4UzeU9c8Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-collection": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0",
@@ -3137,6 +3182,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3174,9 +3234,9 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
-      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.0",
@@ -3198,9 +3258,9 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
-      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0",
@@ -4978,24 +5038,15 @@
       "license": "MIT"
     },
     "node_modules/class-variance-authority": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
-      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "clsx": "2.0.0"
+        "clsx": "^2.1.1"
       },
       "funding": {
-        "url": "https://joebell.co.uk"
-      }
-    },
-    "node_modules/class-variance-authority/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/client-only": {
@@ -9171,9 +9222,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.441.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.441.0.tgz",
-      "integrity": "sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==",
+      "version": "0.461.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.461.0.tgz",
+      "integrity": "sha512-Scpw3D/dV1bgVRC5Kh774RCm99z0iZpPv75M6kg7QL1lLvkQ1rmI1Sjjic1aGp1ULBwd7FokV6ry0g+d6pMB+w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
@@ -9222,9 +9273,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.0.tgz",
-      "integrity": "sha512-0mouKmBROJv/WSHJBPZZyYofUgawMChnD5je/g+aOBXsHDjb/IsnTQj7mnhQZu+qPJmRQ0ecX3mLGEUm3BgwYA==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.2.tgz",
+      "integrity": "sha512-85RUkoYKIVB21PbMKrnD6aCl9ws+XKEyhJNMbLn206NyD3jbBo7Ec7Wi4Jrsn4dV1a2ng7K/jfkmIN0DNoS41w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -9891,9 +9942,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -10006,9 +10057,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.45",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10026,8 +10077,8 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -10339,12 +10390,12 @@
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
-      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
       "license": "MIT",
       "dependencies": {
-        "react-remove-scroll-bar": "^2.3.4",
+        "react-remove-scroll-bar": "^2.3.6",
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.1.0",
         "use-callback-ref": "^1.3.0",
@@ -10461,15 +10512,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
-      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.3.tgz",
+      "integrity": "sha512-YDZ9dOfK9t3ycwxgKbrnDlRC4BHdjlY73fet3a0C1+qGMjXVZe6+VXmpOIIhzkje5MMEL8AN4hLIe4AMskBzlA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
-        "react-is": "^16.10.2",
+        "react-is": "^18.3.1",
         "react-smooth": "^4.0.0",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
@@ -10491,6 +10542,12 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -11321,9 +11378,9 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.2.tgz",
-      "integrity": "sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.5.tgz",
+      "integrity": "sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11331,33 +11388,33 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
-      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
+      "integrity": "sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==",
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
+        "chokidar": "^3.6.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.3.0",
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
+        "jiti": "^1.21.6",
         "lilconfig": "^2.1.0",
-        "micromatch": "^4.0.5",
+        "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.1",
-        "postcss-nested": "^6.0.1",
-        "postcss-selector-parser": "^6.0.11",
-        "resolve": "^1.22.2",
-        "sucrase": "^3.32.0"
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -20,23 +20,25 @@
     "test:coverage": "jest --coverage --silent"
   },
   "dependencies": {
-    "@radix-ui/react-avatar": "1.1.0",
-    "@radix-ui/react-dropdown-menu": "2.1.1",
-    "@radix-ui/react-icons": "1.3.0",
-    "@radix-ui/react-navigation-menu": "1.2.0",
-    "class-variance-authority": "0.7.0",
+    "@radix-ui/react-avatar": "1.1.1",
+    "@radix-ui/react-dropdown-menu": "2.1.2",
+    "@radix-ui/react-icons": "1.3.2",
+    "@radix-ui/react-navigation-menu": "1.2.1",
+    "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "lucide-react": "0.441.0",
-    "marked": "15.0.0",
+    "lucide-react": "0.461.0",
+    "marked": "15.0.2",
     "next": "14.2.11",
     "next-sitemap": "4.2.3",
     "octokit": "4.0.2",
     "react": "18",
     "react-dom": "18",
-    "recharts": "2.12.7",
-    "tailwind-merge": "2.5.2",
+    "recharts": "2.13.3",
+    "tailwind-merge": "2.5.5",
+    "tailwindcss": "3.4.15",
     "tailwindcss-animate": "1.0.7",
-    "ts-node": "10.9.2"
+    "ts-node": "10.9.2",
+    "typescript": "5.4.5"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "3.1.0",
@@ -54,9 +56,7 @@
     "jest-environment-jsdom": "29.7.0",
     "postcss": "8",
     "prettier": "3.3.3",
-    "resize-observer-polyfill": "1.5.1",
-    "tailwindcss": "3.4.1",
-    "typescript": "5.4.5"
+    "resize-observer-polyfill": "1.5.1"
   },
   "prettier": {
     "plugins": [


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes multiple updates to the `dashboard/package-lock.json` file, primarily focusing on updating dependencies to their latest versions. Below is a summary of the most important changes:

Dependency updates:

* Updated `@radix-ui/react-avatar` from `1.1.0` to `1.1.1`.
* Updated `@radix-ui/react-dropdown-menu` from `2.1.1` to `2.1.2`.
* Updated `@radix-ui/react-icons` from `1.3.0` to `1.3.2`.
* Updated `@radix-ui/react-navigation-menu` from `1.2.0` to `1.2.1`.
* Updated `class-variance-authority` from `0.7.0` to `0.7.1`.
* Updated `lucide-react` from `0.441.0` to `0.461.0`.
* Updated `marked` from `15.0.0` to `15.0.2`.
* Updated `recharts` from `2.12.7` to `2.13.3`.
* Updated `tailwind-merge` from `2.5.2` to `2.5.5`.
* Added `typescript` version `5.4.5`.

Additional dependency updates:

* Updated `@floating-ui/core` from `1.6.7` to `1.6.8`.
* Updated `@floating-ui/dom` from `1.6.10` to `1.6.12`.
* Updated `@floating-ui/utils` from `0.2.7` to `0.2.8`.
* Updated `@floating-ui/react-dom` from `2.1.1` to `2.1.2`.

Context-specific updates:

* Added `@radix-ui/react-avatar/node_modules/@radix-ui/react-context` version `1.1.1`.
* Added `@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context` version `1.1.1`.
* Added `@radix-ui/react-menu/node_modules/@radix-ui/react-context` version `1.1.1`.
* Added `@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-context` version `1.1.1`.

This comprehensive update ensures that the project dependencies are up-to-date, which can help improve stability, security, and performance.