### PR TITLE
chore: Ungroup Major Application Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,9 @@ updates:
       typescript:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "docker"
     directory: "docker/dashboard"
@@ -67,3 +70,6 @@ updates:
       docker:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/dependabot.yml` file to specify the types of updates Dependabot should handle for certain package ecosystems. The most important changes include adding `update-types` for both the `typescript` and `docker` ecosystems.

Dependabot configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R55-R57): Added `update-types` for the `typescript` ecosystem to include "patch" and "minor" updates.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R73-R75): Added `update-types` for the `docker` ecosystem to include "patch" and "minor" updates.

Fixes #337 