### PR TITLE
ci: Update CodeLimit Action and Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -258,17 +258,15 @@ jobs:
           sarif_file: results.sarif
 
   run-code-limit:
-    name: Code Limit Analysis
+    name: Run Code Limit
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: "Run Code Limit"
-        uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          upload: true
+        uses: getcodelimit/codelimit-action@v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflow configuration to update the `run-code-limit` job. The most important changes include renaming the job, updating permissions, and changing the action version used.

Updates to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L261-R272): Renamed the `run-code-limit` job from "Code Limit Analysis" to "Run Code Limit"
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L261-R272): Updated permissions for the `run-code-limit` job to include `contents: write` and `pull-requests: write`
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L261-R272): Changed the action version for `getcodelimit/codelimit-action` from a specific commit to `v1`

Fixes #344 
