### PR TITLE
chore: Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,9 +20,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Lint and Format everything but Python/JavaScript/TypeScript
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.0
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -55,10 +56,11 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dashboard Dependencies
         uses: ./.github/actions/setup-dashboard-dependencies
       - name: Run Prettier
@@ -72,10 +74,11 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dashboard Dependencies
         uses: ./.github/actions/setup-dashboard-dependencies
       - name: Run ESLint
@@ -99,6 +102,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Test Dependencies
         uses: ./.github/actions/setup-test-dependencies
       - name: Check Python Code Quality (Ruff)
@@ -121,6 +125,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Test Dependencies
         uses: ./.github/actions/setup-test-dependencies
       - name: Check Python Code Quality (Ruff)
@@ -141,10 +146,11 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
@@ -160,10 +166,11 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Just
         uses: extractions/setup-just@v2
       - name: Check Justfile Format
@@ -179,8 +186,11 @@ jobs:
       matrix:
         language: [python, javascript]
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3.27.5
         with:
@@ -199,6 +209,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@v4.1.0
         with:
@@ -227,6 +238,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dashboard Dependencies
         uses: ./.github/actions/setup-dashboard-dependencies
       - name: Copy example file to github pages folder
@@ -245,6 +257,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@v1
 
@@ -254,7 +267,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup and Deploy Dashboard
         uses: ./.github/actions/setup-and-deploy-dashboard
         with:
@@ -56,6 +57,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Test Dependencies
         uses: ./.github/actions/setup-test-dependencies
       - name: Run UI Tests
@@ -72,6 +74,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run Link Tests
         uses: JustinBeckwith/linkinator-action@v1.11.0
         with:

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize]
 
 permissions:
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check-pr-title:
@@ -20,6 +20,8 @@ jobs:
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Label Pull Request
         uses: actions/labeler@v5.0.0
@@ -46,7 +48,10 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4.5.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows to improve security and consistency. The changes primarily involve setting the `persist-credentials` option to `false` and renaming steps for clarity.

Security and consistency improvements:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R23-R26): Set `persist-credentials: false` for all `actions/checkout` steps and renamed "Checkout Repository" steps to "Checkout". [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R23-R26) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L58-R63) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L75-R81) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R105) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R128) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L144-R153) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L163-R173) [[8]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L182-R193) [[9]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R212) [[10]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R241) [[11]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R260) [[12]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L257-R270)
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R30): Set `persist-credentials: false` for all `actions/checkout` steps. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R30) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R60) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R77)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL8-R8): Changed `pull-requests` permission from `write` to `read` and added `pull-requests: write` permission for the `labeller` job. Renamed "Checkout Repository" step to "Checkout" and set `persist-credentials: false`. [[1]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL8-R8) [[2]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR23-R24) [[3]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL49-R55)
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6R23): Set `persist-credentials: false` for the `actions/checkout` step.

Fixes #359 
