### PR TITLE
refactor: Unify Repository Type

### DIFF
--- a/dashboard/app/(pages)/repository/[name]/page.tsx
+++ b/dashboard/app/(pages)/repository/[name]/page.tsx
@@ -1,13 +1,5 @@
 import { CommitsPieChart } from "@/components/PieChart";
-
-import repositories from "../../../../data/repository_statistics.json";
-
-interface Repository {
-  repository: string;
-  total_files: number;
-  total_commits: number;
-  commits: Record<string, number | undefined>;
-}
+import repositories, { Repository } from "@/lib/repository_statistics";
 
 export async function generateStaticParams() {
   return repositories.map((repository: Repository) => ({

--- a/dashboard/components/SideBar.tsx
+++ b/dashboard/components/SideBar.tsx
@@ -13,8 +13,7 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
-
-import repositories from "../data/repository_statistics.json";
+import repositories, { Repository } from "@/lib/repository_statistics";
 
 export default function AppSidebar() {
   return (
@@ -60,13 +59,6 @@ export default function AppSidebar() {
   );
 }
 
-interface Repository {
-  repository: string;
-  total_files: number;
-  total_commits: number;
-  commits: Record<string, number | undefined>;
-  languages: Record<string, number | undefined>;
-}
 function RepositoriesSubMenuItems() {
   const sortedRepositories = [...repositories].sort((a, b) =>
     a.repository.localeCompare(b.repository),

--- a/dashboard/lib/repository_statistics.ts
+++ b/dashboard/lib/repository_statistics.ts
@@ -1,0 +1,11 @@
+import repositories from "../data/repository_statistics.json";
+
+export interface Repository {
+  repository: string;
+  total_files: number;
+  total_commits: number;
+  commits: Record<string, number | undefined>;
+  languages: Record<string, number | undefined>;
+}
+
+export default repositories as Repository[];


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to improve the organization and reusability of the `Repository` interface and the `repositories` import. The most important changes involve moving the `Repository` interface and `repositories` import to a centralized location in the `dashboard/lib` directory.

Changes to improve organization and reusability:

* `dashboard/app/(pages)/repository/[name]/page.tsx`: Removed the local definition of the `Repository` interface and the import of `repositories` from a relative path, and replaced them with imports from `dashboard/lib/repository_statistics`. ([dashboard/app/(pages)/repository/[name]/page.tsxL2-R2](diffhunk://#diff-8018d7573da2c0793502f6a906948f6b14e46fcf4aeef4f9f33c2a6d47943b45L2-R2))
* [`dashboard/components/SideBar.tsx`](diffhunk://#diff-789a55c11f3c7300c5678f37f83847350e681afdd7621d5141a72296b473dd0cL16-R16): Removed the local definition of the `Repository` interface and the import of `repositories` from a relative path, and replaced them with imports from `dashboard/lib/repository_statistics`. [[1]](diffhunk://#diff-789a55c11f3c7300c5678f37f83847350e681afdd7621d5141a72296b473dd0cL16-R16) [[2]](diffhunk://#diff-789a55c11f3c7300c5678f37f83847350e681afdd7621d5141a72296b473dd0cL63-L69)
* [`dashboard/lib/repository_statistics.ts`](diffhunk://#diff-d1da7cd10578e3dc1d398ea092482fcb37a3a91392ab70d7649b46f4a16da68bR1-R11): Added the `Repository` interface and the import of `repositories` from the JSON file, and exported them for use in other files.
