### PR TITLE
chore: Set some job runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -115,7 +115,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -81,7 +81,7 @@ jobs:
 
   run-python-code-checks:
     name: Run Python Code Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       statuses: write
       security-events: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
 
   ui-tests:
     name: UI Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: deploy
     steps:
       - name: Checkout


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `check-markdown-links` job in the `.github/workflows/code-checks.yml` file. The change updates the runner to use `ubuntu-22.04` instead of `ubuntu-latest`.

Change in GitHub Actions workflow configuration:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L118-R118): Updated the runner for the `check-markdown-links` job from `ubuntu-latest` to `ubuntu-22.04`.