### PR TITLE
ci: Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -117,7 +117,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       statuses: write
     steps:
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to ensure the use of the latest versions and configurations for the GitHub Actions workflows.

Updates to GitHub Actions workflows:

* Changed the `runs-on` parameter for the `check-markdown-links` job to use `ubuntu-latest` instead of a specific version.
* Updated the `uses` parameter for the `check-markdown-links` job to use `UmbrellaDocs/action-linkspector@v1.2.5` instead of `v1.2.4`.