### PR TITLE
chore: Retry UI Tests

### DIFF
--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -527,6 +527,22 @@ pytest = ">=7.0.0"
 typing-extensions = "*"
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "15.0"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pytest-rerunfailures-15.0.tar.gz", hash = "sha256:2d9ac7baf59f4c13ac730b47f6fa80e755d1ba0581da45ce30b72fb3542b4474"},
+    {file = "pytest_rerunfailures-15.0-py3-none-any.whl", hash = "sha256:dd150c4795c229ef44320adc9a0c0532c51b78bb7a6843a8c53556b9a611df1a"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=7.4,<8.2.2 || >8.2.2"
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -766,4 +782,4 @@ dev = ["ruff", "zizmor"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "dc453c3a690d1465ffcbd71077af865a1d06fb89926a6a7353fff14ed3b4a4fd"
+content-hash = "a35d94e32d19952a09017ccd42da961918f758dbab01f79a38203284fcfaf31f"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "pytest-bdd==8.1.0",
   "defusedxml==0.7.1",
   "selenium==4.27.1",
+  "pytest-rerunfailures==15.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -9,13 +9,13 @@ install:
 # Run End-to-End Tests
 run:
     PROJECT_URL=https://jackplowman.github.io/github-stats \
-    poetry run pytest end_to_end --gherkin-terminal-reporter -vv
+    poetry run pytest end_to_end --gherkin-terminal-reporter -vv --reruns 2
 
 # Run End-to-End Tests with dashboard running locally
 run-local:
     PROJECT_URL=http://localhost:8000 \
     ENVIRONMENT=local \
-    poetry run pytest end_to_end --gherkin-terminal-reporter -vvvv
+    poetry run pytest end_to_end --gherkin-terminal-reporter -vvvv --reruns 2
 
 # Remove all compiled Python files
 clean:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the testing setup to improve the reliability of end-to-end tests by adding a new dependency and modifying the test execution commands.

Testing improvements:

* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dR11): Added `pytest-rerunfailures==15.0` to the list of dependencies.
* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L12-R18): Updated the `run` and `run-local` commands to include the `--reruns 2` option, allowing failed tests to be retried up to two times.

Fixes #435
