### PR TITLE
chore: Update GitHub Action Versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -72,7 +72,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.6
+        uses: github/codeql-action/upload-sarif@v3.28.9
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -102,7 +102,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.6
+        uses: github/codeql-action/upload-sarif@v3.28.9
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -169,13 +169,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.6
+        uses: github/codeql-action/init@v3.28.9
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.6
+        uses: github/codeql-action/analyze@v3.28.9
 
   typescript-unit-tests:
     name: Test TypeScript Code
@@ -195,7 +195,7 @@ jobs:
       - name: Run Unit Tests
         run: just dashboard::unit-test-coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4.2.1
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -251,7 +251,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.6
+        uses: github/codeql-action/upload-sarif@v3.28.9
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to ensure the use of the latest versions of certain GitHub actions. The most important changes include updating the versions of the `upload-sarif`, `init`, `analyze`, and `sonarqube-scan` actions.

Updates to GitHub actions:

* Updated `upload-sarif` action to version `v3.28.9` in multiple steps to ensure the latest features and fixes are used. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L75-R75) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L105-R105) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L254-R254)
* Updated `init` and `analyze` actions to version `v3.28.9` to maintain consistency with the `upload-sarif` action.
* Updated `sonarqube-scan` action to version `v5.0.0` to leverage the latest improvements and capabilities.
