### PR TITLE
chore: Add More Hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,7 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Dashboard Checks:
+      run: just dashboard::lint
+    Python Ruff Checks:
+      run: just tests::ruff-checks

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 requires-python = ">=3.13"
 dependencies = [
   "requests==2.32.3",
-  "pytest==8.3.4",
+  "pytest==8.3.5",
   "pytest-bdd==8.1.0",
   "defusedxml==0.7.1",
   "selenium==4.29.0",
@@ -15,7 +15,7 @@ dependencies = [
 dev = ["ruff==0.9.9", "zizmor==1.4.1"]
 
 [tool.uv]
-required-version = "0.6.3"
+required-version = "0.6.4"
 package=false
 
 [tool.ruff]

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -4,7 +4,7 @@
 
 # Install All Python Dependencies
 install:
-    uv sync --extra dev
+    uv sync --all-extras
 
 # Run End-to-End Tests
 run:

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -221,7 +221,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -229,9 +229,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]
@@ -370,7 +370,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "defusedxml", specifier = "==0.7.1" },
-    { name = "pytest", specifier = "==8.3.4" },
+    { name = "pytest", specifier = "==8.3.5" },
     { name = "pytest-bdd", specifier = "==8.1.0" },
     { name = "pytest-rerunfailures", specifier = "==15.0" },
     { name = "requests", specifier = "==2.32.3" },


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to pre-commit hooks, dependency versions, and test configurations. The most important changes are grouped by theme below:

### Pre-commit Hook Updates:
* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dR21-R24): Added new checks for the dashboard and Python Ruff.

### Dependency Version Updates:
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL7-R7): Updated `pytest` to version 8.3.5 and `uv` to version 0.6.4. [[1]](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL7-R7) [[2]](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL18-R18)

### Test Configuration Updates:
* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L7-R7): Modified the `install` command to include all extras instead of just dev extras.
