### PR TITLE
ci: Add Lefthook Validate Job

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
         install-chromedriver: true
         install-dependencies: true
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@v5.3.0
+      uses: astral-sh/setup-uv@v5.3.1
       with:
         pyproject-file: "tests/pyproject.toml"
         enable-cache: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -72,7 +72,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.9
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -102,7 +102,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.9
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -153,6 +153,22 @@ jobs:
       - name: Check Justfile Format
         run: just format-check
 
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.3.1
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate
+
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
@@ -169,13 +185,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.9
+        uses: github/codeql-action/init@v3.28.10
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.9
+        uses: github/codeql-action/analyze@v3.28.10
 
   typescript-unit-tests:
     name: Test TypeScript Code
@@ -251,7 +267,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.9
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the GitHub Actions workflows and dependencies. The most important changes involve updating the versions of various actions and adding a new job for Lefthook validation.

Updates to GitHub Actions versions:

* [`.github/actions/setup-test-dependencies/action.yml`](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144L16-R16): Updated `astral-sh/setup-uv` action from version `v5.3.0` to `v5.3.1`
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L75-R75): Updated `github/codeql-action/upload-sarif` action from version `v3.28.9` to `v3.28.10` in multiple places [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L75-R75) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L105-R105) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L254-R270)
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L172-R194): Updated `github/codeql-action/init` and `github/codeql-action/analyze` actions from version `v3.28.9` to `v3.28.10`

Addition of Lefthook validation job:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R156-R171): Added a new job `lefthook-validate` to validate Lefthook configuration using the latest version of `uv`
