### PR TITLE
chore: Remove Deploy Concurrency Cancel In Progress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change removes the `cancel-in-progress` property from the `concurrency` group configuration.