### PR TITLE
ci: Upload Analyser Output

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -18,6 +18,12 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}
 
+    - name: Upload Analyser Output
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: repository_statistics
+        path: repository_statistics.json
+
     - name: Copy generated files to github pages folder
       shell: bash
       run: cp -r repository_statistics.json dashboard/data


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the GitHub Actions workflow for setting up and deploying the dashboard. The most important change is the addition of a step to upload the analyzer output as an artifact.

GitHub Actions workflow update:

* [`.github/actions/setup-and-deploy-dashboard/action.yml`](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9R21-R26): Added a new step to upload the analyzer output, `repository_statistics.json`, as an artifact using `actions/upload-artifact@v4.6.2`.
