### PR TITLE
chore: Update Dependabot Configuration for UV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
           - "patch"
           - "minor"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "tests"
     commit-message:
       prefix: "deps(python-tests)"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/dependabot.yml` file to adjust the package ecosystem for dependency updates in the `tests` directory.

Configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L25-R25): Changed the `package-ecosystem` for the `tests` directory from `"pip"` to `"uv"`. This likely reflects a switch to a different dependency management tool or ecosystem for Python tests.