### PR TITLE
ci: Pin GitHub Actions 1

### DIFF
--- a/.github/actions/setup-dashboard-dependencies/action.yml
+++ b/.github/actions/setup-dashboard-dependencies/action.yml
@@ -10,10 +10,8 @@ runs:
         node-version: "22.8.0"
         cache: "npm"
         cache-dependency-path: "dashboard/package-lock.json"
-
     - name: Set up Just
-      uses: extractions/setup-just@v3
-
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
     - name: Install Dashboard Dependencies
       shell: bash
       run: just dashboard::install

--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -5,9 +5,9 @@ runs:
   using: "composite"
   steps:
     - name: Set up Just
-      uses: extractions/setup-just@v3
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@v5.4.2
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
         pyproject-file: "tests/pyproject.toml"
         enable-cache: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -151,7 +151,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Check Justfile Format
         run: just format-check
 
@@ -165,7 +165,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.2
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -213,7 +213,7 @@ jobs:
       - name: Run Unit Tests
         run: just dashboard::unit-test-coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.1.0
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the versions of several GitHub Actions in workflows and action definitions to use specific commit SHAs instead of version tags. This change ensures that the workflows use fixed, immutable versions of the actions, improving security and stability.

### Updates to GitHub Actions:

* [`.github/actions/setup-dashboard-dependencies/action.yml`](diffhunk://#diff-f9870bea14450f1c76432e388b314c2cca7f7f040812d75faab93e56630e1865L13-R14): Updated the `setup-just` action to use a specific commit SHA (`e33e0265a09d6d736e2ee1e0eb685ef1de4669ff`) instead of the `v3` tag.

* `.github/actions/setup-test-dependencies/action.yml`:  
  - Updated the `setup-just` action to use the same specific commit SHA as above.  
  - Updated the `setup-uv` action to use a specific commit SHA (`d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`) instead of the `v5.4.2` tag.

* `.github/workflows/code-checks.yml`:  
  - Updated the `setup-just` action to use the specific commit SHA (`e33e0265a09d6d736e2ee1e0eb685ef1de4669ff`).  
  - Updated the `setup-uv` action to use the specific commit SHA (`d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`).  
  - Updated the `sonarqube-scan-action` to use a specific commit SHA (`aa494459d7c39c106cc77b166de8b4250a32bb97`) instead of the `v5.1.0` tag.