### PR TITLE
ci: Pin GitHub Actions 2

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/setup-dashboard-dependencies
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@v1.3.0
+      uses: JackPlowman/github-stats-analyser@733f0168dbb590c0898b22a7bd0f7e70ccf63295 # v1.3.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -130,7 +130,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.4
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -249,7 +249,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@v1
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
 
   run-zizmor:
     name: Check GitHub Actions with zizmor

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Link Tests
-        uses: JustinBeckwith/linkinator-action@v1.11.0
+        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: https://jackplowman.github.io/github-stats
           recurse: true

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Pull Request Title
-        uses: deepakputhraya/action-pr-title@v1.0.2
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
 
@@ -30,7 +30,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: micnncim/action-label-syncer@v1.3.0
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates various GitHub Actions to use specific commit SHAs instead of version tags for improved security and reproducibility. The changes ensure that the workflows reference immutable versions of the actions, preventing potential issues caused by changes in the tagged versions.

### Updates to GitHub Actions:

* **Setup and Deploy Dashboard**: Updated `JackPlowman/github-stats-analyser` action to use commit `733f0168dbb590c0898b22a7bd0f7e70ccf63295` instead of the `v1.3.0` tag. (`.github/actions/setup-and-deploy-dashboard/action.yml`, [.github/actions/setup-and-deploy-dashboard/action.ymlL16-R16](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9L16-R16))

* **Code Checks Workflow**:
  - Updated `UmbrellaDocs/action-linkspector` action to use commit `a0567ce1c7c13de4a2358587492ed43cab5d0102` instead of the `v1.3.4` tag. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL133-R133](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L133-R133))
  - Updated `getcodelimit/codelimit-action` action to use commit `a036c6897be9ccf69cde9dfe50eafa8cd79c98f8` instead of the `v1` tag. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL252-R252](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L252-R252))

* **Deploy Workflow**: Updated `JustinBeckwith/linkinator-action` action to use commit `3d5ba091319fa7b0ac14703761eebb7d100e6f6d` instead of the `v1.11.0` tag. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL78-R78](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L78-R78))

* **Pull Request Tasks Workflow**:
  - Updated `deepakputhraya/action-pr-title` action to use commit `3864bebc79c5f829d25dd42d3c6579d040b0ef16` instead of the `v1.0.2` tag. (`.github/workflows/pull-request-tasks.yml`, [.github/workflows/pull-request-tasks.ymlL16-R16](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL16-R16))
  - Updated `pascalgn/size-label-action` action to use commit `f8edde36b3be04b4f65dcfead05dc8691b374348` instead of the `v0.5.5` tag. (`.github/workflows/pull-request-tasks.yml`, [.github/workflows/pull-request-tasks.ymlL33-R33](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL33-R33))

* **Sync Labels Workflow**: Updated `micnncim/action-label-syncer` action to use commit `3abd5ab72fda571e69fffd97bd4e0033dd5f495c` instead of the `v1.3.0` tag. (`.github/workflows/sync-labels.yml`, [.github/workflows/sync-labels.ymlL24-R24](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L24-R24))
