### PR TITLE
ci: Pin GitHub Actions 3

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python/JavaScript/TypeScript
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/workflows/code-checks.yml` file. The change updates the `super-linter` action to use a specific commit hash instead of a version tag for increased stability and reproducibility.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L28-R28): Updated the `super-linter` GitHub Action reference from `v7.3.0` to the commit hash `4e8a7c2bf106c4c766c816b35ec612638dc9b6b2` to ensure consistent behavior.