### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/actions/setup-dashboard-dependencies/action.yml
+++ b/.github/actions/setup-dashboard-dependencies/action.yml
@@ -11,7 +11,7 @@ runs:
         cache: "npm"
         cache-dependency-path: "dashboard/package-lock.json"
     - name: Set up Just
-      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Dashboard Dependencies
       shell: bash
       run: just dashboard::install

--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Just
-      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
       uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:

--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -151,7 +151,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -248,7 +248,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1.0.0 
 
   run-zizmor:
     name: Check GitHub Actions with zizmor

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -248,7 +248,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1.0.0 
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1.0.0
 
   run-zizmor:
     name: Check GitHub Actions with zizmor

--- a/Justfile
+++ b/Justfile
@@ -70,6 +70,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.10
+min_version: 1.11.11
 colors: true
 
 output:
@@ -18,6 +18,8 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Checks:
+      run: just pinact-check
     Dashboard Checks:
       run: just dashboard::lint
     Python Ruff Checks:


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces updates to dependency versions, adds configuration for the `pinact` tool, and integrates `pinact` into the development workflow. Below is a summary of the most important changes grouped by theme:

### Dependency Updates
* Updated the `setup-just` action version from `v3` to `v3.0.0` in `.github/actions/setup-dashboard-dependencies/action.yml`, `.github/actions/setup-test-dependencies/action.yml`, and `.github/workflows/code-checks.yml`. [[1]](diffhunk://#diff-f9870bea14450f1c76432e388b314c2cca7f7f040812d75faab93e56630e1865L14-R14) [[2]](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144L8-R8) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L154-R154)
* Updated the `getcodelimit/codelimit-action` version from `v1` to `v1.0.0` in `.github/workflows/code-checks.yml`.
* Incremented the minimum required version of `lefthook` from `1.11.10` to `1.11.11` in `lefthook.yml`.

### Pinact Integration
* Added a new configuration file `.github/other-configurations/pinact.yml` for the `pinact` tool, specifying schema, version, and actions to ignore.
* Introduced `pinact` commands (`pinact-run`, `pinact-check`, `pinact-update`) in the `Justfile` to enable running, verifying, and updating `pinact` checks.
* Integrated `pinact` checks into the `lefthook` pre-commit hooks in `lefthook.yml`.
