### PR TITLE
ci: Run Tests in Multiple Browsers

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -1,6 +1,12 @@
 name: "Setup Dependencies"
 description: "Installs dependencies for the project"
 
+inputs:
+  setup-browsers:
+    description: "Whether to set up browsers for Playwright"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -11,8 +17,9 @@ runs:
       with:
         working-directory: tests
     - name: Install Playwright Dependencies
+      if: ${{ inputs.setup-browsers == 'true' }}
       shell: bash
-      run: just tests::playwright-install-minimum
+      run: just tests::playwright-install
     - name: Install Python Dependencies
       shell: bash
       run: just tests::install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,9 +69,7 @@ jobs:
         shell: bash
         run: just tests::playwright-install
       - name: Run UI Tests
-        run: just tests::run-in-browser
-        env:
-          BROWSER: ${{ matrix.browser }}
+        run: just tests::run-ci ${{ matrix.browser }}
 
   link-tests:
     name: Link Tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,21 +48,30 @@ jobs:
         uses: actions/deploy-pages@v4.0.5
 
   ui-tests:
-    name: UI Tests
+    name: Run UI Tests in ${{ matrix.browser }}
     runs-on: ubuntu-latest
     needs: deploy
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [firefox, chromium, webkit]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Test Dependencies
+      - name: Set up Python Tests Dependencies
         uses: ./.github/actions/setup-test-dependencies
+        with:
+          setup-browsers: true
+      - name: Install Playwright Dependencies
+        shell: bash
+        run: just tests::playwright-install
       - name: Run UI Tests
-        run: just tests::run
+        run: just tests::run-in-browser
         env:
-          HEADLESS: true
+          BROWSER: ${{ matrix.browser }}
 
   link-tests:
     name: Link Tests

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -1,4 +1,10 @@
 # ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+export DEFAULT_PROJECT_URL := "https://jackplowman.github.io/github-stats"
+
+# ------------------------------------------------------------------------------
 # General Commands
 # ------------------------------------------------------------------------------
 
@@ -7,20 +13,16 @@ install:
     uv sync --all-extras
 
 # Run End-to-End Tests
-run:
-    PROJECT_URL=https://jackplowman.github.io/github-stats \
-    uv run pytest ui -vv --reruns 2
+run $PROJECT_URL=DEFAULT_PROJECT_URL $browser="chromium":
+    uv run pytest ui -vv --reruns 2 --browser ${browser}
 
 # Run End-to-End Tests with dashboard running locally
-run-local:
-    PROJECT_URL=http://localhost:8000 \
-    ENVIRONMENT=local \
-    uv run pytest ui -vvvv --reruns 2
+run-local $project_url="TODO":
+    just tests::run ${project_url}
 
-# Run End-to-End Tests in browser
-run-in-browser:
-    PROJECT_URL=https://jackplowman.github.io/github-stats \
-    uv run pytest ui -vv --reruns 2 --browser ${BROWSER}
+# Run End-to-End Tests in a specific browser
+run-ci $browser:
+    just tests::run $DEFAULT_PROJECT_URL ${browser}
 
 # Install playwright dependencies
 playwright-install:

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -17,13 +17,14 @@ run-local:
     ENVIRONMENT=local \
     uv run pytest ui -vvvv --reruns 2
 
+# Run End-to-End Tests in browser
+run-in-browser:
+    PROJECT_URL=https://jackplowman.github.io/github-stats \
+    uv run pytest ui -vv --reruns 2 --browser ${BROWSER}
+
 # Install playwright dependencies
 playwright-install:
-    uv run playwright install
-
-# Install playwright minimum dependencies
-playwright-install-minimum:
-    uv run playwright install --with-deps --only-shell chromium
+    uv run playwright install --with-deps
 
 # Remove all compiled Python files
 clean:


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several updates to improve the test setup, streamline workflows, and enhance the flexibility of end-to-end (E2E) testing. Key changes include adding browser configuration options for Playwright, enabling matrix testing for multiple browsers, and refactoring test scripts to support these enhancements.

### Enhancements to Test Setup and Configuration:
* [`.github/actions/setup-test-dependencies/action.yml`](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144R4-R9): Added an optional `setup-browsers` input to conditionally install Playwright browser dependencies. Updated the Playwright installation step to respect this input. [[1]](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144R4-R9) [[2]](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144R20-R22)

### Workflow Improvements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L51-R72): Updated the "UI Tests" job to use a matrix strategy for testing across multiple browsers (`firefox`, `chromium`, `webkit`). Adjusted the test dependencies setup and test execution commands to align with the matrix configuration.

### Refactoring of Test Scripts:
* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R1-R6): Refactored test commands to support browser-specific testing. Introduced a `run-ci` command for running tests in a specific browser and a `DEFAULT_PROJECT_URL` environment variable for easier configuration. Removed the `playwright-install-minimum` command in favor of a unified `playwright-install` command. [[1]](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R1-R6) [[2]](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L10-R29)

Fixes #596 
