### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -27,7 +27,7 @@ updates:
       prefix: "deps(python-tests)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       python:
@@ -40,7 +40,7 @@ updates:
       prefix: "deps(typescript)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       typescript:
@@ -56,7 +56,7 @@ updates:
       prefix: "deps(docker)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       docker:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -27,9 +26,8 @@ updates:
     commit-message:
       prefix: "deps(python-tests)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       python:
@@ -41,9 +39,8 @@ updates:
     commit-message:
       prefix: "deps(typescript)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       typescript:
@@ -58,10 +55,8 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       docker:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the scheduling configuration for Dependabot in the `.github/dependabot.yml` file. It replaces the existing `interval`-based schedules with a unified `cron`-based schedule for all dependency update groups.

### Scheduling Configuration Changes:

* Updated the `github-actions` dependency group to use a `cron` schedule of `"30 7 * * *"` instead of a daily interval at 01:00 London time.
* Updated the `python-tests` dependency group to use a `cron` schedule of `"30 7 * * *"` instead of a daily interval at 01:00 London time.
* Updated the `typescript` dependency group to use a `cron` schedule of `"30 7 * * *"` instead of a daily interval at 01:00 London time.
* Updated the `docker` dependency group to use a `cron` schedule of `"30 7 * * *"` instead of a weekly interval on Saturdays at 01:00 London time.