### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       - ".github/actions/setup-and-deploy-dashboard"
       - ".github/actions/setup-dashboard-dependencies"
       - ".github/actions/setup-test-dependencies"
+    commit-message:
+      prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,18 @@ updates:
       - ".github/actions/setup-and-deploy-dashboard"
       - ".github/actions/setup-dashboard-dependencies"
       - ".github/actions/setup-test-dependencies"
-    commit-message:
-      prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -28,9 +30,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
+        applies-to: "version-updates"
         patterns:
           - "*"
 
@@ -41,9 +45,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       typescript:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -57,9 +63,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       docker:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to enhance scheduling and grouping functionality for dependency updates. The key changes include adding a timezone for the cron schedule and introducing the `applies-to` and `exclude-patterns` options for better group control.

### Scheduling Improvements:
* Added the `timezone` field to specify "Europe/London" for the cron job schedule, ensuring updates run at the correct local time. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R15-R23) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R35-R39) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R50-R54) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R68-R72)

### Group Configuration Enhancements:
* Introduced the `applies-to` field with the value "version-updates" for all dependency groups (`github-actions`, `python`, `typescript`, and `docker`) to refine the scope of updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R15-R23) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R35-R39) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R50-R54) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R68-R72)
* Added `exclude-patterns` to the `github-actions` group to exclude updates matching the pattern "super-linter/*".