### PR TITLE
chore: Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -261,14 +261,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up dependencies
-        uses: ./.github/actions/setup-test-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv --project tests run zizmor --format sarif .. > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -67,7 +67,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the code-checking workflow and the `Justfile` to improve dependency management and streamline the execution of the `zizmor` tool. Key changes include replacing the custom dependency setup with third-party actions, updating how `zizmor` is run, and ensuring compatibility with the latest versions of tools.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L264-R273): Replaced the custom `setup-test-dependencies` action with third-party actions for installing `uv` (`astral-sh/setup-uv@v6.0.1`) and setting up `Just` (`extractions/setup-just@v3`).
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L264-R273): Updated the `zizmor` execution step to use the `just zizmor-check-sarif` command instead of running `uv` directly.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L264-R273): Upgraded the `upload-sarif` action from version `v3.28.15` to `v3.28.17` for better compatibility.

### `Justfile` updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL70-R74): Added a new `zizmor-check-sarif` target to run `zizmor` with SARIF output using `uvx`. Updated the existing `zizmor-check` target to also use `uvx` for consistency.