### PR TITLE
ci: Pin all GitHub Actions

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -19,7 +19,7 @@ runs:
         REPOSITORY_OWNER: ${{ github.repository_owner }}
 
     - name: Upload Analyser Output
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: repository_statistics
         path: repository_statistics.json
@@ -33,10 +33,10 @@ runs:
       run: just dashboard::build
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3.0.1
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       with:
         path: dashboard/out
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4.0.5
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/actions/setup-dashboard-dependencies/action.yml
+++ b/.github/actions/setup-dashboard-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js with Cache
-      uses: actions/setup-node@v4.4.0
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: "22.8.0"
         cache: "npm"

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,7 +19,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -73,7 +73,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -103,7 +103,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -125,7 +125,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -146,7 +146,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -182,17 +182,17 @@ jobs:
         language: [python, typescript, actions]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.15
+        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.15
+        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
 
   typescript-unit-tests:
     name: Test TypeScript Code
@@ -201,7 +201,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -224,7 +224,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -243,7 +243,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -257,20 +257,20 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Run zizmor 🌈
         run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.17
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       pages: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   ui-tests:
     name: Run UI Tests in ${{ matrix.browser }}
@@ -57,7 +57,7 @@ jobs:
         browser: [firefox, chromium, webkit]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -77,7 +77,7 @@ jobs:
     needs: deploy
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label Pull Request
-        uses: actions/labeler@v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
@@ -51,11 +51,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.6.0
+        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
         with:
           comment-summary-in-pr: on-failure

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the versions of various GitHub Actions across multiple workflow files by pinning them to specific commit SHAs instead of version tags. This change improves the security and reliability of the workflows by ensuring that the actions always use the exact version intended.

### Updates to GitHub Actions Versions

#### General Actions Updates:
* Updated `actions/checkout` to commit `11bd71901bbe5b1630ceea73d27597364c9af683` across multiple workflows, replacing version `v4.2.2`. (`[[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L22-R22)`, `[[2]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL17-R17)`, `[[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L26-R26)`, and others)
* Updated `actions/upload-artifact` to commit `ea165f8d65b6e75b540449e92b4886f43607fa02` in `.github/actions/setup-and-deploy-dashboard/action.yml`, replacing version `v4.6.2`. (`[.github/actions/setup-and-deploy-dashboard/action.ymlL22-R22](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9L22-R22)`)
* Updated `actions/upload-pages-artifact` to commit `56afc609e74202658d3ffba0e8f6dda462b719fa` in `.github/actions/setup-and-deploy-dashboard/action.yml`, replacing version `v3.0.1`. (`[.github/actions/setup-and-deploy-dashboard/action.ymlL36-R42](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9L36-R42)`)
* Updated `actions/deploy-pages` to commit `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` in `.github/actions/setup-and-deploy-dashboard/action.yml` and `.github/workflows/deploy.yml`, replacing version `v4.0.5`. (`[[1]](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9L36-R42)`, `[[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L48-R48)`)

#### Code Analysis and Dependency Management:
* Updated `github/codeql-action` for SARIF upload, initialization, and analysis to commit `45775bd8235c68ba998cffa5171334d58593da47` in `.github/workflows/code-checks.yml`, replacing version `v3.28.15`. (`[[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L76-R76)`, `[[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L106-R106)`, `[[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L185-R195)`)
* Updated `actions/dependency-review-action` to commit `ce3cf9537a52e8119d91fd484ab5b8a807627bf8` in `.github/workflows/pull-request-tasks.yml`, replacing version `v4.6.0`. (`[.github/workflows/pull-request-tasks.ymlL54-R59](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL54-R59)`)

#### Other Actions:
* Updated `actions/setup-node` to commit `49933ea5288caeca8642d1e84afbd3f7d6820020` in `.github/actions/setup-dashboard-dependencies/action.yml`, replacing version `v4.4.0`. (`[.github/actions/setup-dashboard-dependencies/action.ymlL8-R8](diffhunk://#diff-f9870bea14450f1c76432e388b314c2cca7f7f040812d75faab93e56630e1865L8-R8)`)
* Updated `actions/labeler` to commit `8558fd74291d67161a8a78ce36a881fa63b766a9` in `.github/workflows/pull-request-tasks.yml`, replacing version `v5.0.0`. (`[.github/workflows/pull-request-tasks.ymlL27-R27](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL27-R27)`)
* Updated `extractions/setup-just` to commit `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` in `.github/workflows/code-checks.yml`, replacing version `v3.0.0`. (`[.github/workflows/code-checks.ymlL260-R273](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L260-R273)`)