### PR TITLE
test: Update homepage tests to repositories tests

### DIFF
--- a/tests/ui/test_repositories.py
+++ b/tests/ui/test_repositories.py
@@ -2,23 +2,23 @@ from logging import getLogger
 
 from playwright.sync_api import Page
 
-from ui.utils.variables import PROJECT_URL
+from ui.utils.variables import REPOSITORIES_URL
 
 logger = getLogger(__name__)
 
 
 def test_title(page: Page) -> None:
-    """Test the homepage title."""
+    """Test the repositories title."""
     # Act
-    page.goto(PROJECT_URL)
+    page.goto(REPOSITORIES_URL)
     # Assert
     assert page.title() == "GitHub Stats Dashboard"
 
 
-def test_homepage_content(page: Page) -> None:
-    """Test the homepage content."""
+def test_repositories_content(page: Page) -> None:
+    """Test the repositories content."""
     # Act
-    page.goto(PROJECT_URL)
+    page.goto(REPOSITORIES_URL)
     # Assert
     assert page.locator("h1").text_content() == "Repositories"
     repository_links = page.locator("[data-testid='repository-link']")

--- a/tests/ui/utils/variables.py
+++ b/tests/ui/utils/variables.py
@@ -3,6 +3,8 @@ from os import getenv
 GITHUB_PAGES_URL = "https://jackplowman.github.io/github-stats"
 
 PROJECT_URL = getenv("PROJECT_URL") if getenv("PROJECT_URL") else GITHUB_PAGES_URL
+REPOSITORIES_URL = f"{PROJECT_URL}/repositories"
+
 SITEMAP_URL_PREFIX = GITHUB_PAGES_URL
 EXPECTED_XML_CONTENT_TYPE = (
     "text/xml" if getenv("ENVIRONMENT") == "local" else "application/xml"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the UI test suite to reflect a shift in focus from the homepage to the repositories page. The most important changes include renaming a test file, updating test functions and variables, and introducing a new URL for the repositories page.

### Updates to the UI test suite:

* Renamed the test file `tests/ui/test_homepage.py` to `tests/ui/test_repositories.py` and updated its content to focus on repositories instead of the homepage. This includes changes to test function names, docstrings, and the URL being tested.

* Added a new variable `REPOSITORIES_URL` in `tests/ui/utils/variables.py` to construct the repositories page URL dynamically based on the `PROJECT_URL`.