### PR TITLE
ci: Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -126,28 +126,17 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [python, typescript, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        language: [actions, typescript, python]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   typescript-unit-tests:
     name: Test TypeScript Code


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` file to streamline and simplify the CodeQL analysis workflow by using a reusable workflow. The changes also include minor adjustments to permissions and matrix language definitions.

### Workflow simplification:

* Renamed the `run-codeql-analysis` job to `codeql-checks` and replaced its inline configuration with a reference to a reusable workflow (`JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493`).

### Permission and configuration updates:

* Updated permissions for the `codeql-checks` job by replacing `statuses: write` with `contents: read` while retaining `security-events: write`.
* Adjusted the matrix language definition in the `codeql-checks` job to reorder languages as `[actions, typescript, python]` for consistency.