### PR TITLE
deps(github-actions): Bump reusable-workflows to 2025.05.24.02

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -122,7 +122,7 @@ jobs:
       contents: read
       pull-requests: read
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@09b627d7b66ab6743aca41282c91199796973b39 # v2025.05.16.04
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -120,7 +120,7 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       security-events: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     secrets:

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,6 +21,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@09b627d7b66ab6743aca41282c91199796973b39 # v2025.05.16.04
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the reusable workflows used in the repository to a newer version (`v2025.05.24.02`) across multiple workflow files. These updates ensure consistency and incorporate any improvements or fixes in the latest version of the reusable workflows.

### Workflow Updates:
* Updated the reusable workflow reference in `.github/workflows/clean-caches.yml` to version `v2025.05.24.02`.
* Updated the reusable workflow references in `.github/workflows/code-checks.yml` for both `common-code-checks.yml` and `codeql-analysis.yml` to version `v2025.05.24.02`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L125-R125) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L137-R137)
* Updated the reusable workflow reference in `.github/workflows/pull-request-tasks.yml` to version `v2025.05.24.02`.
* Updated the reusable workflow reference in `.github/workflows/sync-labels.yml` to version `v2025.05.24.02`.
