### PR TITLE
test: Fix UI Tests

### DIFF
--- a/tests/ui/test_repositories.py
+++ b/tests/ui/test_repositories.py
@@ -22,7 +22,7 @@ def test_repositories_content(page: Page) -> None:
     # Assert
     assert page.locator("h1").text_content() == "Repositories"
     repository_links = page.locator("[data-testid='repository-link']")
-    assert repository_links.count() == 31
+    assert repository_links.count() == 32
     assert (
         repository_links.first.get_attribute("href")
         == "/github-stats/repository/actions-status"

--- a/tests/ui/test_repositories.py
+++ b/tests/ui/test_repositories.py
@@ -40,6 +40,7 @@ def test_repositories_content(page: Page) -> None:
         "JackPlowman",
         "project-links",
         "project-status-checker",
+        "projects",
         "python-practise",
         "repo_standards_validator",
         "repo-overseer",


### PR DESCRIPTION
# Pull Request

## Description


This pull request updates a test case in `tests/ui/test_repositories.py` to reflect a change in the expected number of repository links on the page.

Test case update:

* [`tests/ui/test_repositories.py`](diffhunk://#diff-18684b3b8dbb8b4785694160f807327ff53dd63b4400dbad6159d04e8fff675aL25-R25): Modified the assertion in `test_repositories_content` to expect 32 repository links instead of 31, likely due to the addition of a new repository link.
