### PR TITLE
deps(github-actions): Update GitHub Actions and Reusable Workflow

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/setup-dashboard-dependencies
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@733f0168dbb590c0898b22a7bd0f7e70ccf63295 # v1.3.0
+      uses: JackPlowman/github-stats-analyser@bef0d7135e14ee15bb9c13b9d1091a93dc23f658 # v2.0.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         working-directory: tests
     - name: Install Playwright Dependencies

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -71,7 +71,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -101,7 +101,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -122,7 +122,7 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,6 +21,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and reusable workflows in the GitHub Actions configuration to use newer versions. These changes ensure compatibility, access to new features, and bug fixes across various workflows.

### Dependency Updates:
* [`.github/actions/setup-and-deploy-dashboard/action.yml`](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9L16-R16): Updated `JackPlowman/github-stats-analyser` from v1.3.0 to v2.0.0.
* [`.github/actions/setup-test-dependencies/action.yml`](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144L16-R16): Updated `astral-sh/setup-uv` from v6.0.1 to v6.1.0.

### Reusable Workflow Updates:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated `common-clean-caches.yml` reusable workflow to v2025.06.04.02.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L125-R125): Updated `common-code-checks.yml` and `codeql-analysis.yml` reusable workflows to v2025.06.04.02. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L125-R125) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L137-R137)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL24-R24): Updated `common-pull-request-tasks.yml` reusable workflow to v2025.06.04.02.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated `common-sync-labels.yml` reusable workflow to v2025.06.04.02.

### CodeQL Action Updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L74-R74): Updated `github/codeql-action/upload-sarif` from v3.28.18 to v3.28.19 for both ESLint and Ruff analysis results. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L74-R74) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L104-R104)