### PR TITLE
fix: Revert Analyser Action

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/setup-dashboard-dependencies
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@bef0d7135e14ee15bb9c13b9d1091a93dc23f658 # v2.0.0
+      uses: JackPlowman/github-stats-analyser@733f0168dbb590c0898b22a7bd0f7e70ccf63295 # v1.3.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `GitHub Stats Analyser` action in the `setup-and-deploy-dashboard` workflow. The previous version (v2.0.0) has been replaced with an earlier version (v1.3.0). 

This change is located in the file `.github/actions/setup-and-deploy-dashboard/action.yml`.
