### PR TITLE
chore: Exclude Key Dependencies from Dependabot Group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,10 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "nextjs"
+          - "react"
+          - "typescript"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to exclude certain dependencies from automatic updates.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R58-R61): Added `exclude-patterns` to prevent Dependabot from automatically updating dependencies related to `nextjs`, `react`, and `typescript`.
