### PR TITLE
ci: Set FORCE_COLOR in workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check-code-quality:
     name: Check Code Quality


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces an environment variable to enforce colored output in the code quality checks workflow.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R14-R16): Added the `FORCE_COLOR` environment variable to ensure colored output during the execution of the code quality checks.