### PR TITLE
deps(github-actions): Bump GitHub Actions and Reusable Workflows

### DIFF
--- a/.github/actions/setup-tests-dependencies/action.yml
+++ b/.github/actions/setup-tests-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
         working-directory: tests
     - name: Install Playwright Dependencies

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -74,7 +74,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        uses: github/codeql-action/upload-sarif@39edc492dbe16b1465b0cafca41432d857bdb31a # v3.29.1
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -104,7 +104,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        uses: github/codeql-action/upload-sarif@39edc492dbe16b1465b0cafca41432d857bdb31a # v3.29.1
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -167,7 +167,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -179,7 +179,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,6 +21,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tests"
 dynamic = ["version"]
-requires-python = "~=3.13"
+requires-python = "~=3.13.0"
 dependencies = [
   "requests==2.32.4",
   "pytest==8.4.0",
@@ -15,7 +15,7 @@ dependencies = [
 dev = ["ruff==0.12.0", "ty==0.0.1a11"]
 
 [tool.uv]
-required-version = "0.7.13"
+required-version = "0.7.16"
 package = false
 
 [tool.ruff]

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13, <4"
+requires-python = ">=3.13.0, <3.14"
 
 [[package]]
 name = "certifi"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to dependencies and reusable workflows across multiple files to ensure compatibility and incorporate the latest features. Key changes include upgrading action versions, updating reusable workflow references, and modifying Python dependency specifications.

### Dependency Updates:
* [`.github/actions/setup-tests-dependencies/action.yml`](diffhunk://#diff-263e089eb2c5a46d8ce6caaccaaaf176722ae4e8da320d6cd2b779fa67c6ffcdL16-R16): Updated `astral-sh/setup-uv` action from version `v6.1.0` to `v6.3.1`.
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL4-R4): Adjusted `requires-python` to specify `~=3.13.0` instead of `~=3.13` for clarity and updated `tool.uv` required version from `0.7.13` to `0.7.16`. [[1]](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL4-R4) [[2]](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL18-R18)

### Workflow Updates:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated reusable workflow reference for `common-clean-caches.yml` to version `v2025.06.28.03`.
* `.github/workflows/code-checks.yml`: 
  - Updated `github/codeql-action/upload-sarif` action from version `v3.29.0` to `v3.29.1`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L77-R77) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L107-R107)
  - Updated reusable workflow references for `common-code-checks.yml` and `codeql-analysis.yml` to version `v2025.06.28.03`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L170-R170) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L182-R182)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL24-R24): Updated reusable workflow reference for `common-pull-request-tasks.yml` to version `v2025.06.28.03`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19): Updated reusable workflow reference for `common-sync-labels.yml` to version `v2025.06.28.03`.