### PR TITLE
ci: Set Link Job to Not Recursive Search

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,6 @@ jobs:
         uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: https://jackplowman.github.io/github-stats
-          recurse: true
+          recurse: false
           timeout: 1000
           markdown: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/workflows/deploy.yml` file. The change modifies the `recurse` option in the `linkinator-action` configuration from `true` to `false` to adjust the behavior of link checking.