### PR TITLE
ci: Swap Out Link Checker Tests with new action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,9 +84,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Link Tests
-        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
+        uses: filiph/linkcheck@f2c15a0be0d9c83def5df3edcc0f2d6582845f2d # 3.0.0
         with:
-          paths: https://jackplowman.github.io/github-stats
-          recurse: false
-          timeout: 1000
-          markdown: false
+          arguments: https://jackplowman.github.io/github-stats


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the link-checking tool used in the GitHub Actions workflow for deployment. The change replaces the `linkinator-action` tool with the `linkcheck` tool and modifies its configuration.

### Workflow updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L87-R89): Replaced `linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d` with `linkcheck@f2c15a0be0d9c83def5df3edcc0f2d6582845f2d` for running link tests, updating the tool version to `3.0.0` and switching from `paths`/`recurse`/`timeout`/`markdown` options to a single `arguments` option.
