### PR TITLE
deps(github-actions): Bump Reusable Workflows and GitHub Actions

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/setup-dashboard-dependencies
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@733f0168dbb590c0898b22a7bd0f7e70ccf63295 # v1.3.0
+      uses: JackPlowman/github-stats-analyser@bef0d7135e14ee15bb9c13b9d1091a93dc23f658 # v2.0.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/setup-dashboard-dependencies
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@bef0d7135e14ee15bb9c13b9d1091a93dc23f658 # v2.0.0
+      uses: JackPlowman/github-stats-analyser@733f0168dbb590c0898b22a7bd0f7e70ccf63295 # v1.3.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@4f08c95e8d485c7772fcf62fc52698dbe0876846 # v2025.07.07.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -74,7 +74,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@39edc492dbe16b1465b0cafca41432d857bdb31a # v3.29.1
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -104,7 +104,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@39edc492dbe16b1465b0cafca41432d857bdb31a # v3.29.1
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -167,7 +167,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@4f08c95e8d485c7772fcf62fc52698dbe0876846 # v2025.07.07.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -179,7 +179,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@4f08c95e8d485c7772fcf62fc52698dbe0876846 # v2025.07.07.01
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,6 +21,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@4f08c95e8d485c7772fcf62fc52698dbe0876846 # v2025.07.07.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@4bb8b8a2160453d60573d10fda4d553152b68560 # v2025.06.28.03
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@4f08c95e8d485c7772fcf62fc52698dbe0876846 # v2025.07.07.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows to use newer versions of reusable workflows and actions. These updates ensure compatibility, incorporate the latest fixes, and potentially improve performance or security. Below is a summary of the most important changes grouped by theme:

### Updates to reusable workflows:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated the reusable workflow `common-clean-caches.yml` to version `v2025.07.07.01` (`4f08c95e8d485c7772fcf62fc52698dbe0876846`).
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L170-R170): Updated the reusable workflows `common-code-checks.yml` and `codeql-analysis.yml` to version `v2025.07.07.01` (`4f08c95e8d485c7772fcf62fc52698dbe0876846`). [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L170-R170) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L182-R182)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL24-R24): Updated the reusable workflow `common-pull-request-tasks.yml` to version `v2025.07.07.01` (`4f08c95e8d485c7772fcf62fc52698dbe0876846`).
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19): Updated the reusable workflow `common-sync-labels.yml` to version `v2025.07.07.01` (`4f08c95e8d485c7772fcf62fc52698dbe0876846`).

### Updates to GitHub Actions:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L77-R77): Updated the `upload-sarif` action from version `v3.29.1` (`39edc492dbe16b1465b0cafca41432d857bdb31a`) to version `v3.29.2` (`181d5eefc20863364f96762470ba6f862bdef56b`). This update was applied to both ESLint and Ruff SARIF uploads. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L77-R77) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L107-R107)