### PR TITLE
ci: Split TypeScript Code Checks Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,10 +79,25 @@ jobs:
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
-      - name: Run Prettier
-        run: just dashboard::prettier-check
       - name: Run ESLint
         run: just dashboard::lint
+
+  run-typescript-format-checks:
+    name: Run TypeScript Format Checks
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Dashboard Dependencies
+        uses: ./.github/actions/setup-dashboard-dependencies
+      - name: Run Prettier
+        run: just dashboard::prettier-check
 
   run-python-tests-lint-checks:
     name: Run Python Tests Lint Checks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` file to improve the organization and coverage of code checks. The most significant change is the addition of a new job for TypeScript format checks, which ensures better code consistency.

### Workflow Updates:

* **Added a new job for TypeScript format checks**: Introduced a `run-typescript-format-checks` job that includes steps for checking out the repository, setting up dependencies, and running Prettier for TypeScript files. This job enhances the workflow by ensuring TypeScript code adheres to formatting standards.

* **Removed Prettier check from the main job**: The Prettier check was removed from the main job (`Run ESLint`) and moved into the new `run-typescript-format-checks` job for better separation of concerns.