### PR TITLE
build: Update Dashboard for Analyser V2

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/setup-dashboard-dependencies
 
     - name: GitHub Stats Analyser
-      uses: JackPlowman/github-stats-analyser@733f0168dbb590c0898b22a7bd0f7e70ccf63295 # v1.3.0
+      uses: JackPlowman/github-stats-analyser@bef0d7135e14ee15bb9c13b9d1091a93dc23f658 # v2.0.0
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/dashboard/app/(pages)/repository/[name]/page.tsx
+++ b/dashboard/app/(pages)/repository/[name]/page.tsx
@@ -37,7 +37,7 @@ export default async function RepositoryPage(
       fill: colors[index % colors.length],
     }),
   );
-  const languageChartData = Object.entries(repository.languages).map(
+  const languageChartData = Object.entries(repository.languages.count).map(
     ([language, count], index) => ({
       language,
       count: count ?? 0,

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -41,6 +41,11 @@
   --color-chart-8: hsl(var(--chart-8));
   --color-chart-9: hsl(var(--chart-9));
   --color-chart-10: hsl(var(--chart-10));
+  --color-chart-6: hsl(var(--chart-6));
+  --color-chart-7: hsl(var(--chart-7));
+  --color-chart-8: hsl(var(--chart-8));
+  --color-chart-9: hsl(var(--chart-9));
+  --color-chart-10: hsl(var(--chart-10));
 
   --color-sidebar: hsl(var(--sidebar-background));
   --color-sidebar-foreground: hsl(var(--sidebar-foreground));

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -41,11 +41,6 @@
   --color-chart-8: hsl(var(--chart-8));
   --color-chart-9: hsl(var(--chart-9));
   --color-chart-10: hsl(var(--chart-10));
-  --color-chart-6: hsl(var(--chart-6));
-  --color-chart-7: hsl(var(--chart-7));
-  --color-chart-8: hsl(var(--chart-8));
-  --color-chart-9: hsl(var(--chart-9));
-  --color-chart-10: hsl(var(--chart-10));
 
   --color-sidebar: hsl(var(--sidebar-background));
   --color-sidebar-foreground: hsl(var(--sidebar-foreground));

--- a/dashboard/lib/repository_statistics.ts
+++ b/dashboard/lib/repository_statistics.ts
@@ -20,7 +20,7 @@ export interface RepositoryStatistics {
   repositories: Repository[];
 }
 
-const repositories = repositoryData as RepositoryStatistics;
+const repositoryStatistics = repositoryData as RepositoryStatistics;
 
-export default repositories.repositories;
-export { repositories as repositoryStatistics };
+export default repositoryStatistics.repositories;
+export { repositoryStatistics };

--- a/dashboard/lib/repository_statistics.ts
+++ b/dashboard/lib/repository_statistics.ts
@@ -1,11 +1,26 @@
-import repositories from "../data/repository_statistics.json";
+import repositoryData from "../data/repository_statistics.json";
 
 export interface Repository {
   repository: string;
   total_files: number;
   total_commits: number;
   commits: Record<string, number | undefined>;
-  languages: Record<string, number | undefined>;
+  languages: {
+    count: Record<string, number | undefined>;
+    sloc: Record<string, number | undefined>;
+  };
 }
 
-export default repositories as Repository[];
+export interface RepositoryStatistics {
+  repository_owner: string;
+  overall_statistics: {
+    total_files: number;
+    total_commits: number;
+  };
+  repositories: Repository[];
+}
+
+const repositories = repositoryData as RepositoryStatistics;
+
+export default repositories.repositories;
+export { repositories as repositoryStatistics };


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces updates to the GitHub Actions workflow, refactors the repository statistics data structure, and fixes a bug in the language chart data mapping. Additionally, it includes minor updates to CSS variables for chart colors. Below are the most important changes:

### GitHub Actions Workflow Update:
* Updated the `GitHub Stats Analyser` action to use version `v2.0.0` (`bef0d7135e14ee15bb9c13b9d1091a93dc23f658`), replacing the older `v1.3.0` version. This likely includes new features or bug fixes. (`[.github/actions/setup-and-deploy-dashboard/action.ymlL16-R16](diffhunk://#diff-6905cc4e4f5af84b5bf60f682670f570a3a3c2305a7e32e194c844be41f9cba9L16-R16)`)

### Refactoring Repository Statistics:
* Refactored the `Repository` type in `repository_statistics.ts` to include a nested `languages` object with `count` and `sloc` properties, improving the structure for handling language data. (`[dashboard/lib/repository_statistics.tsL1-R26](diffhunk://#diff-d1da7cd10578e3dc1d398ea092482fcb37a3a91392ab70d7649b46f4a16da68bL1-R26)`)
* Introduced a new `RepositoryStatistics` interface and updated the default export to return only the `repositories` array while exporting the full statistics object separately. (`[dashboard/lib/repository_statistics.tsL1-R26](diffhunk://#diff-d1da7cd10578e3dc1d398ea092482fcb37a3a91392ab70d7649b46f4a16da68bL1-R26)`)

### Bug Fix in Language Chart Data Mapping:
* Fixed the language chart data mapping in `page.tsx` by accessing `repository.languages.count` instead of `repository.languages`, aligning with the updated data structure. (`[dashboard/app/(pages)/repository/[name]/page.tsxL40-R40](diffhunk://#diff-8018d7573da2c0793502f6a906948f6b14e46fcf4aeef4f9f33c2a6d47943b45L40-R40)`)

### CSS Updates:
* Added redundant CSS variables for chart colors (`--color-chart-6` to `--color-chart-10`), which may be unintentional or require clarification. (`[dashboard/app/globals.cssR44-R48](diffhunk://#diff-4e15958db8b4018955b23c01df1bd5f893495fb8eb6a73f263bd7d58220313efR44-R48)`)