### PR TITLE
test: Add Summary Page Tests

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -33,6 +33,7 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
+          FILTER_REGEX_EXCLUDE: "TEST_PLAN.md"
           YAML_ERROR_ON_WARNING: true
           VALIDATE_CSS: false
           VALIDATE_EDITORCONFIG: false

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
   "requests==2.32.4",
   "pytest==8.4.1",
   "defusedxml==0.7.1",
-  "playwright==1.53.0",
+  "playwright==1.54.0",
   "pytest-playwright==0.7.0",
   "pytest-rerunfailures==15.1",
 ]

--- a/tests/ui/test_summary.py
+++ b/tests/ui/test_summary.py
@@ -13,25 +13,21 @@ def test_summary_page_layout(page: Page) -> None:
     expect(page.get_by_text("GitHub Stats Summary")).to_be_visible()
 
     # Key facts
-    expect(page.locator("p", has_text="Total Commits")).to_be_visible()
-    expect(page.locator("p", has_text="Total Files")).to_be_visible()
-    expect(page.locator("p", has_text="Contributors")).to_be_visible()
-    expect(page.locator("p", has_text="Languages Used")).to_be_visible()
+    for fact in [
+        "Total Commits",
+        "Total Files",
+        "Contributors",
+        "Languages Used",
+    ]:
+        expect(page.locator("p", has_text=fact)).to_be_visible()
 
     # Graphs
-    expect(
-        page.locator('div[data-slot="card-header"]', has_text="Total Commits")
-    ).to_be_visible()
-    expect(
-        page.locator('div[data-slot="card-header"]', has_text="File Count Per Type")
-    ).to_be_visible()
-    expect(
-        page.locator(
-            'div[data-slot="card-header"]', has_text="Top Repositories by Commits"
-        )
-    ).to_be_visible()
-    expect(
-        page.locator(
-            'div[data-slot="card-header"]', has_text="Top Repositories by Files"
-        )
-    ).to_be_visible()
+    for graph in [
+        "Commits Over Time",
+        "Files Over Time",
+        "Top Contributors by Commits",
+        "Top Contributors by Files",
+    ]:
+        expect(
+            page.locator('div[data-slot="card-header"]', has_text=graph)
+        ).to_be_visible()

--- a/tests/ui/test_summary.py
+++ b/tests/ui/test_summary.py
@@ -1,0 +1,25 @@
+from playwright.sync_api import Page, expect
+
+from ui.utils.variables import PROJECT_URL
+
+
+def test_summary_page_layout(page: Page) -> None:
+    """Test the layout of the summary page."""
+    # Act
+    page.goto(PROJECT_URL)
+
+    # Assert
+    # Page title
+    expect(page.get_by_text("GitHub Stats Summary")).to_be_visible()
+
+    # Key facts
+    expect(page.locator("p", has_text="Total Commits")).to_be_visible()
+    expect(page.locator("p", has_text="Total Files")).to_be_visible()
+    expect(page.locator("p", has_text="Contributors")).to_be_visible()
+    expect(page.locator("p", has_text="Languages Used")).to_be_visible()
+
+    # Graphs
+    expect(page.locator('div[data-slot="card-header"]', has_text="Total Commits")).to_be_visible()
+    expect(page.locator('div[data-slot="card-header"]', has_text="File Count Per Type")).to_be_visible()
+    expect(page.locator('div[data-slot="card-header"]', has_text="Top Repositories by Commits")).to_be_visible()
+    expect(page.locator('div[data-slot="card-header"]', has_text="Top Repositories by Files")).to_be_visible()

--- a/tests/ui/test_summary.py
+++ b/tests/ui/test_summary.py
@@ -19,7 +19,19 @@ def test_summary_page_layout(page: Page) -> None:
     expect(page.locator("p", has_text="Languages Used")).to_be_visible()
 
     # Graphs
-    expect(page.locator('div[data-slot="card-header"]', has_text="Total Commits")).to_be_visible()
-    expect(page.locator('div[data-slot="card-header"]', has_text="File Count Per Type")).to_be_visible()
-    expect(page.locator('div[data-slot="card-header"]', has_text="Top Repositories by Commits")).to_be_visible()
-    expect(page.locator('div[data-slot="card-header"]', has_text="Top Repositories by Files")).to_be_visible()
+    expect(
+        page.locator('div[data-slot="card-header"]', has_text="Total Commits")
+    ).to_be_visible()
+    expect(
+        page.locator('div[data-slot="card-header"]', has_text="File Count Per Type")
+    ).to_be_visible()
+    expect(
+        page.locator(
+            'div[data-slot="card-header"]', has_text="Top Repositories by Commits"
+        )
+    ).to_be_visible()
+    expect(
+        page.locator(
+            'div[data-slot="card-header"]', has_text="Top Repositories by Files"
+        )
+    ).to_be_visible()

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -107,21 +107,21 @@ wheels = [
 
 [[package]]
 name = "playwright"
-version = "1.53.0"
+version = "1.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/e2/2f107be74419280749723bd1197c99351f4b8a0a25e974b9764affb940b2/playwright-1.53.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:48a1a15ce810f0ffe512b6050de9871ea193b41dd3cc1bbed87b8431012419ba", size = 40392498, upload-time = "2025-06-25T21:48:34.17Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d5/e8c57a4f6fd46059fb2d51da2d22b47afc886b42400f06b742cd4a9ba131/playwright-1.53.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a701f9498a5b87e3f929ec01cea3109fbde75821b19c7ba4bba54f6127b94f76", size = 38647035, upload-time = "2025-06-25T21:48:38.414Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f3/da18cd7c22398531316e58fd131243fd9156fe7765aae239ae542a5d07d2/playwright-1.53.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:f765498341c4037b4c01e742ae32dd335622f249488ccd77ca32d301d7c82c61", size = 40392502, upload-time = "2025-06-25T21:48:42.293Z" },
-    { url = "https://files.pythonhosted.org/packages/92/32/5d871c3753fbee5113eefc511b9e44c0006a27f2301b4c6bffa4346fbd94/playwright-1.53.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:db19cb5b58f3b15cad3e2419f4910c053e889202fc202461ee183f1530d1db60", size = 45848364, upload-time = "2025-06-25T21:48:45.849Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6b/9942f86661ff41332f9299db4950623123e60ca71e4fb6e6942fc0212624/playwright-1.53.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9276c9c935fc062f51f4f5107e56420afd6d9a524348dc437793dc2e34c742e3", size = 45235174, upload-time = "2025-06-25T21:48:49.579Z" },
-    { url = "https://files.pythonhosted.org/packages/51/63/28b3f2d36e6a95e88f033d2aa7af06083f6f4aa0d9764759d96033cd053e/playwright-1.53.0-py3-none-win32.whl", hash = "sha256:36eedec101724ff5a000cddab87dd9a72a39f9b3e65a687169c465484e667c06", size = 35415131, upload-time = "2025-06-25T21:48:53.403Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/b5/4ca25974a90d16cfd4a9a953ee5a666cf484a0bdacb4eed484e5cab49e66/playwright-1.53.0-py3-none-win_amd64.whl", hash = "sha256:d68975807a0fd997433537f1dcf2893cda95884a39dc23c6f591b8d5f691e9e8", size = 35415138, upload-time = "2025-06-25T21:48:57.082Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/b42ff2116df5d07ccad2dc4eeb20af92c975a1fbc7cd3ed37b678468b813/playwright-1.53.0-py3-none-win_arm64.whl", hash = "sha256:fcfd481f76568d7b011571160e801b47034edd9e2383c43d83a5fb3f35c67885", size = 31188568, upload-time = "2025-06-25T21:49:00.194Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/09/33d5bfe393a582d8dac72165a9e88b274143c9df411b65ece1cc13f42988/playwright-1.54.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bf3b845af744370f1bd2286c2a9536f474cc8a88dc995b72ea9a5be714c9a77d", size = 40439034, upload-time = "2025-07-22T13:58:04.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/7b/51882dc584f7aa59f446f2bb34e33c0e5f015de4e31949e5b7c2c10e54f0/playwright-1.54.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:780928b3ca2077aea90414b37e54edd0c4bbb57d1aafc42f7aa0b3fd2c2fac02", size = 38702308, upload-time = "2025-07-22T13:58:08.211Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a1/7aa8ae175b240c0ec8849fcf000e078f3c693f9aa2ffd992da6550ea0dff/playwright-1.54.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:81d0b6f28843b27f288cfe438af0a12a4851de57998009a519ea84cee6fbbfb9", size = 40439037, upload-time = "2025-07-22T13:58:11.37Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a9/45084fd23b6206f954198296ce39b0acf50debfdf3ec83a593e4d73c9c8a/playwright-1.54.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:09919f45cc74c64afb5432646d7fef0d19fff50990c862cb8d9b0577093f40cc", size = 45920135, upload-time = "2025-07-22T13:58:14.494Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/6a692f4c6db223adc50a6e53af405b45308db39270957a6afebddaa80ea2/playwright-1.54.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13ae206c55737e8e3eae51fb385d61c0312eeef31535643bb6232741b41b6fdc", size = 45302695, upload-time = "2025-07-22T13:58:18.901Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/4ee60a1c3714321db187bebbc40d52cea5b41a856925156325058b5fca5a/playwright-1.54.0-py3-none-win32.whl", hash = "sha256:0b108622ffb6906e28566f3f31721cd57dda637d7e41c430287804ac01911f56", size = 35469309, upload-time = "2025-07-22T13:58:21.917Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/77/8f8fae05a242ef639de963d7ae70a69d0da61d6d72f1207b8bbf74ffd3e7/playwright-1.54.0-py3-none-win_amd64.whl", hash = "sha256:9e5aee9ae5ab1fdd44cd64153313a2045b136fcbcfb2541cc0a3d909132671a2", size = 35469311, upload-time = "2025-07-22T13:58:24.707Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ff/99a6f4292a90504f2927d34032a4baf6adb498dc3f7cf0f3e0e22899e310/playwright-1.54.0-py3-none-win_arm64.whl", hash = "sha256:a975815971f7b8dca505c441a4c56de1aeb56a211290f8cc214eeef5524e8d75", size = 31239119, upload-time = "2025-07-22T13:58:27.56Z" },
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "defusedxml", specifier = "==0.7.1" },
-    { name = "playwright", specifier = "==1.53.0" },
+    { name = "playwright", specifier = "==1.54.0" },
     { name = "pytest", specifier = "==8.4.1" },
     { name = "pytest-playwright", specifier = "==0.7.0" },
     { name = "pytest-rerunfailures", specifier = "==15.1" },


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces updates to configuration files, dependencies, and test coverage. The key changes include excluding a specific file from linting, upgrading a dependency version, and adding a new UI test for verifying the summary page layout.

### Configuration Updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R36): Added `FILTER_REGEX_EXCLUDE` to exclude `TEST_PLAN.md` from linting.

### Dependency Updates:
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL9-R9): Upgraded `playwright` from version `1.53.0` to `1.54.0`.

### Test Coverage Enhancements:
* [`tests/ui/test_summary.py`](diffhunk://#diff-d3bc78c2bbfc2d1416f8f46f81cc8b09aa3711de20efe6f2aaeba4f562a59dd9R1-R25): Added a new test, `test_summary_page_layout`, to verify the visibility of key elements and graphs on the summary page.