### PR TITLE
chore: Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ This project is released with a [Contributor Code of Conduct](./docs/CODE_OF_CON
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.
+This project is licensed under the MIT Licence. See the [LICENCE](./LICENCE) file for details.


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the spelling of "LICENSE" to "LICENCE" across the codebase to ensure consistency with the naming convention used for the license file.

Documentation and configuration updates:

* Updated the `README.md` to refer to the MIT "Licence" and the `LICENCE` file, instead of "License" and `LICENSE`.
* Changed the file pattern in `.github/other-configurations/labeller.yml` from `LICENSE` to `LICENCE` for markdown labeling.