### PR TITLE
ci: Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   check-pr-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor adjustment to the permissions configuration in the GitHub Actions workflow file `.github/workflows/pull-request-tasks.yml`. The change moves the `pull-requests: read` permission from the global workflow level to the specific job that requires it, resulting in a more restrictive and secure permissions setup.

- Workflow permissions refactor:
  * Removed the global `pull-requests: read` permission and replaced it with an empty permissions object at the workflow level, then added `pull-requests: read` permission specifically to the `check-pr-title` job. This limits the permission scope to only where it's needed.