### PR TITLE
chore: Update Lefthook Minimum Version

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.12.2
+min_version: 1.13.6
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the minimum required version of Lefthook in the `lefthook.yml` configuration file to ensure compatibility with newer features and bug fixes.

- Tooling update:
  * Increased the `min_version` of Lefthook from `1.12.2` to `1.13.6` in `lefthook.yml` for improved compatibility and access to recent updates.