### PR TITLE
deps(github-actions): Update Reusable Workflows

### DIFF
--- a/.github/actions/setup-and-deploy-dashboard/action.yml
+++ b/.github/actions/setup-and-deploy-dashboard/action.yml
@@ -19,7 +19,7 @@ runs:
         REPOSITORY_OWNER: ${{ github.repository_owner }}
 
     - name: Upload Analyser Output
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: repository_statistics
         path: repository_statistics.json

--- a/.github/actions/setup-tests-dependencies/action.yml
+++ b/.github/actions/setup-tests-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@2ddd2b9cb38ad8efd50337e8ab201519a34c9f24 # v7.1.1
+      uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
       with:
         working-directory: tests
     - name: Install Playwright Dependencies

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@0237146b1c8960f0e59f327b21307bd4887da687 # v2025.10.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@067ffe5c04acf220819f000da6656117afc909f6 # v2025.10.29.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -35,7 +35,7 @@ jobs:
         run: just dashboard::eslint-with-sarif
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
         with:
           sarif_file: dashboard/eslint-results.sarif
           wait-for-processing: true
@@ -80,7 +80,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true
@@ -143,7 +143,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@0237146b1c8960f0e59f327b21307bd4887da687 # v2025.10.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@067ffe5c04acf220819f000da6656117afc909f6 # v2025.10.29.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -155,6 +155,6 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@0237146b1c8960f0e59f327b21307bd4887da687 # v2025.10.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@067ffe5c04acf220819f000da6656117afc909f6 # v2025.10.29.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -22,6 +22,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@0237146b1c8960f0e59f327b21307bd4887da687 # v2025.10.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@067ffe5c04acf220819f000da6656117afc909f6 # v2025.10.29.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@0237146b1c8960f0e59f327b21307bd4887da687 # v2025.10.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@067ffe5c04acf220819f000da6656117afc909f6 # v2025.10.29.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions and reusable workflow versions across multiple workflow files to ensure the latest features, security patches, and bug fixes are applied. The most important changes are grouped below by theme.

**Reusable Workflow Version Updates:**

* Updated references to reusable workflows (`common-clean-caches.yml`, `common-code-checks.yml`, `codeql-analysis.yml`, `common-pull-request-tasks.yml`, `common-sync-labels.yml`) from version `v2025.10.24.02` to `v2025.10.29.01` in multiple workflow files for improved reliability and bug fixes. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L146-R146) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L158-R158) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL25-R25) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19)

**Action Version Updates:**

* Upgraded `actions/upload-artifact` in `.github/actions/setup-and-deploy-dashboard/action.yml` from v4.6.2 to v5.0.0 for artifact uploads.
* Upgraded `astral-sh/setup-uv` in `.github/actions/setup-tests-dependencies/action.yml` from v7.1.1 to v7.1.2 for Python and UV setup.
* Upgraded `github/codeql-action/upload-sarif` in `.github/workflows/code-checks.yml` from v4.30.9 to v4.31.2 for uploading SARIF analysis results. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L38-R38) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L83-R83)

These updates help keep our CI/CD workflows current, secure, and compatible with the latest tooling.