### PR TITLE
chore: Set Dependabot Cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "uv"
     directory: "tests"
@@ -40,6 +42,8 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "dashboard"
@@ -62,3 +66,5 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to introduce a cooldown period for dependency updates. The cooldown ensures that Dependabot will wait at least 7 days between opening new pull requests for dependency updates across multiple package ecosystems.

Dependabot configuration changes:

* Added a `cooldown` setting with `default-days: 7` to the `pip` updates section, so new PRs for patch and minor updates will be spaced out by at least 7 days.
* Added a `cooldown` setting with `default-days: 7` to the `uv` updates section, affecting PRs for version updates matching all patterns.
* Added a `cooldown` setting with `default-days: 7` to the `npm` updates section for patch and minor updates.