### PR TITLE
chore: Override urllib3 version

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -17,6 +17,9 @@ dev = ["ruff==0.14.2", "ty==0.0.1a24"]
 [tool.uv]
 required-version = "~=0.9.0"
 package = false
+override-dependencies = [
+  "urllib3==2.6.2",
+]
 
 [tool.ruff]
 target-version = "py313"

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
+[manifest]
+overrides = [{ name = "urllib3", specifier = "==2.6.2" }]
+
 [[package]]
 name = "certifi"
 version = "2025.1.31"
@@ -337,9 +340,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
 ]


### PR DESCRIPTION
# Pull Request

## Description


This pull request adds an override for the `urllib3` dependency in the test configuration to ensure a specific version is used during testing.

Dependency management:

* Added `override-dependencies` to the `[tool.uv]` section in `tests/pyproject.toml` to pin `urllib3` to version `2.6.2`.
