### PR TITLE
ci: Set GitHub Workflow Concurrency

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -8,6 +8,10 @@ on:
       - .github/other-configurations/labels.yml
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to improve concurrency management and ensure that only the latest workflow runs are active for a given pull request or branch. The main focus is on preventing unnecessary duplicate runs and optimizing CI resource usage.

**Workflow concurrency improvements:**

* Added a `concurrency` block to the following workflow files to group runs by workflow and pull request or branch, and to automatically cancel in-progress runs when a new one is triggered:
  * `.github/workflows/clean-caches.yml`
  * `.github/workflows/code-checks.yml`
  * `.github/workflows/pull-request-tasks.yml`
  * `.github/workflows/sync-labels.yml`

**Deployment workflow adjustment:**

* Set `cancel-in-progress: false` in the `concurrency` block of `.github/workflows/deploy.yml` to allow multiple deploy jobs to run concurrently, rather than cancelling in-progress runs.