### PR TITLE
deps(github-actions): Upgrade reusable workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -16,6 +16,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@027686c99ec2d74752ec79051b9bbf00b084eb71 # v2025.11.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@a3a774e20f1269ae0062ad712637513f5040df9d # v2025.12.13.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -147,7 +147,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@027686c99ec2d74752ec79051b9bbf00b084eb71 # v2025.11.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@a3a774e20f1269ae0062ad712637513f5040df9d # v2025.12.13.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -159,6 +159,6 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@027686c99ec2d74752ec79051b9bbf00b084eb71 # v2025.11.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@a3a774e20f1269ae0062ad712637513f5040df9d # v2025.12.13.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
         browser: [firefox, chromium, webkit]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -80,7 +80,7 @@ jobs:
     needs: deploy
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -26,6 +26,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@027686c99ec2d74752ec79051b9bbf00b084eb71 # v2025.11.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a3a774e20f1269ae0062ad712637513f5040df9d # v2025.12.13.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@027686c99ec2d74752ec79051b9bbf00b084eb71 # v2025.11.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@a3a774e20f1269ae0062ad712637513f5040df9d # v2025.12.13.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to use the latest versions of reusable workflows and the `actions/checkout` action. These updates ensure that the workflows benefit from recent improvements, bug fixes, and security patches.

**Reusable workflow version updates:**

* Updated references to all `JackPlowman/reusable-workflows` reusable workflows across `.github/workflows/clean-caches.yml`, `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml` to use version `a3a774e20f1269ae0062ad712637513f5040df9d` (`v2025.12.13.01`). This brings in the latest changes and improvements from the reusable workflows repository. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL19-R19) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L150-R150) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L162-R162) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL29-R29) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L23-R23)

**GitHub Actions version updates:**

* Updated `actions/checkout` from version `v6.0.0` to `v6.0.1` in `.github/workflows/deploy.yml` for both the deploy and post-deploy steps, ensuring the latest fixes and optimizations are used. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L61-R61) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L83-R83)
