### PR TITLE
chore: Update Prek Freeze Command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Justfile
+++ b/Justfile
@@ -104,7 +104,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -117,4 +117,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the pre-commit tooling configuration and related scripts to align with newer versions and improve reproducibility.

Tooling upgrades and configuration:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3): Increased the `minimum_prek_version` from `0.3.0` to `0.4.0` to require a newer version of `prek`.

Prek update process changes:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL107-R107): Changed the `prek-update-hooks` command to use `prek update --freeze` instead of `prek autoupdate`, ensuring dependency versions are locked for reproducible environments.
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL120): Removed the `prek-update-additional-dependencies` step from the `update` recipe, streamlining the update process.